### PR TITLE
Add modify to SplitEpi and SplitMono

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/optics/SplitEpi.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/optics/SplitEpi.scala
@@ -3,6 +3,7 @@
 
 package gsp.math.optics
 
+import cats.Functor
 import cats.arrow.Category
 import monocle.{ Iso, Prism }
 
@@ -21,6 +22,14 @@ import monocle.{ Iso, Prism }
  * @see [[https://ncatlab.org/nlab/show/split+epimorphism Split Epimorphism]] at nLab
  */
 final case class SplitEpi[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Modify the target of the SplitEpi using a function. */
+  def modify(f: B => B): A => A =
+    a => reverseGet(f(get(a)))
+
+  /** Modify the target of the SplitEpi using Functor. */
+  def modifyF[F[_]: Functor](f: B => F[B])(a: A): F[A] =
+    Functor[F].map(f(get(a)))(reverseGet)
 
   /** Swapping `get` and `reverseGet` yields a `SplitMono. */
   def reverse: SplitMono[B, A] =

--- a/modules/math/shared/src/main/scala/gsp/math/optics/SplitMono.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/optics/SplitMono.scala
@@ -3,6 +3,7 @@
 
 package gsp.math.optics
 
+import cats.Functor
 import cats.arrow.Category
 import monocle.{ Fold, Getter, Iso }
 
@@ -18,9 +19,17 @@ import monocle.{ Fold, Getter, Iso }
  *
  * @param get  section of `reverseGet` such that `get andThen reverseGet` is an identity
  * @param reverseGet any function B => A
- * @see [[https://ncatlab.org/nlab/show/split+monomorphism Split Epimorphism]] at nLab
+ * @see [[https://ncatlab.org/nlab/show/split+monomorphism Split Monomorphism]] at nLab
  */
 final case class SplitMono[A, B](get: A => B, reverseGet: B => A) {
+
+  /** Modify the target of the SplitMono using a function. */
+  def modify(f: B => B): A => A =
+    a => reverseGet(f(get(a)))
+
+  /** Modify the target of the SplitMono using Functor. */
+  def modifyF[F[_]: Functor](f: B => F[B])(a: A): F[A] =
+    Functor[F].map(f(get(a)))(reverseGet)
 
   /** Swapping `get` and `reverseGet` yields a `SplitEpi. */
   def reverse: SplitEpi[B, A] =

--- a/modules/math/shared/src/test/scala/gsp/math/optics/SplitEpiSpec.scala
+++ b/modules/math/shared/src/test/scala/gsp/math/optics/SplitEpiSpec.scala
@@ -19,4 +19,12 @@ final class SplitEpiSpec extends CatsSuite {
   checkAll("Int > Byte", SplitEpiTests(ex2).splitEpi)
   checkAll("Long > Int > Byte", SplitEpiTests(ex1 composeSplitEpi ex2).splitEpi)
 
+  test("modify") {
+    ex1.modify(_ + 1)(Int.MaxValue.toLong) shouldEqual Int.MinValue.toLong
+  }
+
+  test("modifyF") {
+    ex1.modifyF(i => Option(i + 1))(Int.MaxValue.toLong) shouldEqual Some(Int.MinValue.toLong)
+  }
+
 }

--- a/modules/math/shared/src/test/scala/gsp/math/optics/SplitMonoSpec.scala
+++ b/modules/math/shared/src/test/scala/gsp/math/optics/SplitMonoSpec.scala
@@ -19,4 +19,12 @@ final class SplitMonoSpec extends CatsSuite {
   checkAll("Int < Long", SplitMonoTests(ex2).splitMono)
   checkAll("Byte < Int < Long", SplitMonoTests(ex1 composeSplitMono ex2).splitMono)
 
+  test("modify") {
+    ex1.modify(_ + 1)(Byte.MaxValue) shouldEqual Byte.MinValue
+  }
+
+  test("modifyF") {
+    ex1.modifyF(i => Option(i + 1))(Byte.MaxValue) shouldEqual Some(Byte.MinValue)
+  }
+
 }


### PR DESCRIPTION
Would it make sense to add `modify` to these optics?  If so, what do you recommend for testing? They don't appear to make sense as fundamental laws.

For example, to halve an `Angle`:

```scala
   Angle.signedMicroarcseconds.modify(_/2)(θ)
```