### PR TITLE
Test artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,8 @@ lazy val math = crossProject(JVMPlatform, JSPlatform)
       "com.github.julien-truffaut" %% "monocle-core"  % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-law"   % monocleVersion % "test"
-    )
+    ),
+    publishArtifact in Test := true
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
   .jsSettings(


### PR DESCRIPTION
I'd like to be able to reuse the arbitraries that we define in `gsp-math`, but I'm not sure how.  If I add 

```
publishArtifact in Test := true
```

to the build then it produces a `gsp-math_2.12-tests.jar` to which presumably I could add a "test" dependency from another project.  Is this the right thing to do?  Unfortunately it will package the test classes themselves as well which is unnecessary but harmless I suppose.