### PR TITLE
Use sbt-gsp for scalac settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,62 +8,6 @@ lazy val kindProjectorVersion = "0.9.10"
 lazy val monocleVersion       = "1.5.0-cats"
 lazy val scala12Version       = "2.12.8"
 
-lazy val scalacSettings = Seq(
-  scalacOptions ++= (
-    Seq(
-      "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-      "-encoding", "utf-8",                // Specify character encoding used by source files.
-      "-explaintypes",                     // Explain type errors in more detail.
-      "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-      "-language:higherKinds",             // Allow higher-kinded types
-      "-language:implicitConversions",     // Allow definition of implicit functions called views
-      "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-      "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-      "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-      "-Xfuture",                          // Turn on future language features.
-      "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-      "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-      "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-      "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-      "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-      "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-      "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
-      "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-      "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-      "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-      "-Xlint:option-implicit",            // Option.apply used implicit view.
-      "-Xlint:package-object-classes",     // Class or object defined in package object.
-      "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-      "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-      "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-      "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-      "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-      "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-      // "-Yno-imports",                      // No predef or default imports
-      "-Ypartial-unification",             // Enable partial unification in type constructor inference
-      "-Ywarn-dead-code",                  // Warn when dead code is identified.
-      "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-      "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-      "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-      "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-      "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
-      "-Ywarn-numeric-widen",              // Warn when numerics are widened.
-      "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-      "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-      "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-      // "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-      "-Ywarn-unused:privates",            // Warn if a private member is unused.
-      "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-      "-Ywarn-macros:before", // via som
-      "-Yrangepos" // for longer squiggles
-    )
-  ),
-  scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
-  scalacOptions in (Compile, doc)     --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
-)
-
 inThisBuild(Seq(
   organization     := "edu.gemini",
   organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)",
@@ -93,7 +37,6 @@ lazy val headerSettings = Seq(
 lazy val math = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/math"))
-  .settings(scalacSettings)
   .settings(headerSettings)
   .settings(
     name := "gsp-math",
@@ -116,7 +59,6 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/testkit"))
   .dependsOn(math)
-  .settings(scalacSettings)
   .settings(headerSettings)
   .settings(
     name := "gsp-math-testkit",
@@ -136,7 +78,6 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/tests"))
   .dependsOn(math, testkit)
-  .settings(scalacSettings)
   .settings(headerSettings)
   .settings(
     name := "gsp-math-tests",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.1")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "5.2.0")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.2.6")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")


### PR DESCRIPTION
This PR updates the `gsp-math` build to use the new `sbt-gsp` SBT plugin to pick up scalac settings. While useful in and of itself, I'm also mostly trying to get everything wired up and prove that it works. There is probably more that we can add to the plugin so that it need not be duplicated across builds. For example:

* header generation and its attributes (I wasn't able to figure out how to do that)
* developer, etc. information for the release plugin

For now `gsp-math` just picks up the `scalacSettings` from the plugin.