### PR TITLE
Use shared header settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,20 +24,9 @@ inThisBuild(Seq(
   addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
 ))
 
-lazy val headerSettings = Seq(
-  // These sbt-header settings can't be set in ThisBuild for some reason
-  headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
-  headerLicense  := Some(HeaderLicense.Custom(
-    """|Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
-       |For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-       |""".stripMargin
-  )),
-)
-
 lazy val math = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/math"))
-  .settings(headerSettings)
   .settings(
     name := "gsp-math",
     libraryDependencies ++= Seq(
@@ -59,7 +48,6 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/testkit"))
   .dependsOn(math)
-  .settings(headerSettings)
   .settings(
     name := "gsp-math-testkit",
     libraryDependencies ++= Seq(
@@ -78,7 +66,6 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/tests"))
   .dependsOn(math, testkit)
-  .settings(headerSettings)
   .settings(
     name := "gsp-math-tests",
     skip in publish := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.1")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "5.2.0")
+addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.2")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.2.6")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
Updates to use the `sbt-gsp` plugin header settings instead of setting them independently here.