### PR TITLE
Use shared publish settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ out/
 # Bloop/Metals
 .bloop/
 .metals/
+
+# Vim
+*.swp

--- a/build.sbt
+++ b/build.sbt
@@ -9,20 +9,9 @@ lazy val monocleVersion       = "1.5.0-cats"
 lazy val scala12Version       = "2.12.8"
 
 inThisBuild(Seq(
-  organization     := "edu.gemini",
-  organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)",
-  startYear        := Some(2019),
-  licenses         += ("BSD-3-Clause", new URL("https://opensource.org/licenses/BSD-3-Clause")),
   homepage := Some(url("https://github.com/gemini-hlsw/gsp-math")),
-  developers := List(
-    Developer("cquiroz",    "Carlos Quiroz",       "cquiroz@gemini.edu",    url("http://www.gemini.edu")),
-    Developer("jluhrs",     "Javier Lührs",        "jluhrs@gemini.edu",     url("http://www.gemini.edu")),
-    Developer("sraaphorst", "Sebastian Raaphorst", "sraaphorst@gemini.edu", url("http://www.gemini.edu")),
-    Developer("swalker2m",  "Shane Walker",        "swalker@gemini.edu",    url("http://www.gemini.edu")),
-    Developer("tpolecat",   "Rob Norris",          "rnorris@gemini.edu",    url("http://www.tpolecat.org")),
-  ),
   addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
-))
+) ++ gspPublishSettings)
 
 lazy val math = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.2")
+addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.5")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.2.6")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
Updates the build to get publish settings from the `sbt-gsp` plugin instead of defining them locally.