### PR TITLE
downgrade sbt-ci-release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.11")
-addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.1") // possible issue in 1.5.2 that causes 2.13 jars to be empty
+addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.0") // possible issue in 1.5.2 (there is no 1.5.1) that causes 2.13 jars to be empty
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.31")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.1.11")
-addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.2")
+addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.1") // possible issue in 1.5.2 that causes 2.13 jars to be empty
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.31")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
sbt-ci-release 1.5.2 added a `clean` step that may be causing the 2.13 jarfiles to end up empty … i want to try a tag with this downgrade and see if it fixes the issue.