### PR TITLE
Disable publishing of the root module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ inThisBuild(Seq(
   addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion),
 ) ++ gspPublishSettings)
 
+skip in publish := true
+
 lazy val math = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
   .in(file("modules/math"))


### PR DESCRIPTION
Previously, the build published the empty "root" project causing release
issues because the directory of the repo matches the module name of the
`gsp-math` project, which is supposed to get published.

* https://twitter.com/sjrdoeraene/status/1230773654910382080
* https://github.com/olafurpg/sbt-ci-release/issues/105