### PR TITLE
Int syntax for Angle + Angle bisect

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/Angle.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Angle.scala
@@ -55,6 +55,13 @@ sealed class Angle protected (val toMicroarcseconds: Long) {
   }
 
   /**
+   * Angle corresponding to the bisection of this Angle.  Approximate, non-invertible.
+   * @group Transformations
+   */
+  def bisect: Angle =
+    Angle.fromMicroarcseconds(toMicroarcseconds / 2L)
+
+  /**
    * This angle in decimal degrees. Approximate, non-invertible.
    * @group Conversions
    */

--- a/modules/math/shared/src/main/scala/gsp/math/syntax/Int.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/syntax/Int.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.syntax
+
+import gsp.math.Angle
+
+final class IntOps(val self: Int) extends AnyVal {
+
+  private def scaled(µas: Long): Angle =
+    Angle.signedMicroarcseconds.reverseGet(self.toLong * µas)
+
+  def degrees: Angle =
+    scaled(1000L * 1000L * 60L * 60L)
+
+  def deg: Angle =
+    degrees
+
+  def arcminutes: Angle =
+    scaled(1000L * 1000L * 60L)
+
+  def arcmin: Angle =
+    arcminutes
+
+  def am: Angle =
+    arcminutes
+
+  def arcseconds: Angle =
+    scaled(1000L * 1000L)
+
+  def arcsec: Angle =
+    arcseconds
+
+  def as: Angle =
+    arcseconds
+
+  def milliarcseconds: Angle =
+    scaled(1000L)
+
+  def mas: Angle =
+    milliarcseconds
+
+  def microarcseconds: Angle =
+    scaled(1)
+
+  def µas: Angle =
+    microarcseconds
+
+}
+
+trait ToIntOps {
+  implicit def ToIntOps(i: Int): IntOps = new IntOps(i)
+}
+
+object int extends ToIntOps

--- a/modules/math/shared/src/main/scala/gsp/math/syntax/package.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/syntax/package.scala
@@ -9,11 +9,12 @@ package gsp.math
  * conversions traits.
  */
 package object syntax {
-  object all extends ToParserOps
+  object all extends ToDurationOps
+                with ToInstantOps
+                with ToIntOps
+                with ToParserOps
                 with ToPrismOps
                 with ToStringOps
-                with ToInstantOps
-                with ToDurationOps
                 with ToTreeMapCompanionOps
                 with ToTreeMapOps
                 with ToTreeSetCompanionOps

--- a/modules/tests/shared/src/test/scala/gsp/math/AngleSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/AngleSpec.scala
@@ -159,4 +159,10 @@ final class AngleSpec extends CatsSuite {
     }
   }
 
+  test("A bisected Angle has half the magnitude") {
+    forAll { (a: Angle) =>
+      val b = (a + a).bisect
+      assert(a === b || a.flip === b)
+    }
+  }
 }


### PR DESCRIPTION
This PR would add some trivial `Int` syntax and a new `Angle` transformation.  Probe arm, science area, etc geometries are all specified in terms of arcseconds so it is natural to define them that way in code.  The idea is you could then define constants in a more readable way.  For example

```scala
object GmosOiwfsProbeArm {
   val PickoffArmLength: Angle      = 358460.mas
   val PickoffMirrorSize: Angle     =     20.arcsec
   val ProbeArmLength: Angle        = PickoffArmLength - PickoffMirrorSize.bisect
   val ProbeArmTaperedWidth: Angle  =     15.arcsec
   val ProbeArmTaperedLength: Angle =    180.arcsec
...
}
```


