### PR TITLE
Added GMOS science area geometry + bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ bin/
 
 # IntelliJ
 .idea/
+*.ipr
+*.iws
 
 # Mill
 out/

--- a/modules/math/shared/src/main/scala/gsp/math/geom/ShapeExpression.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/geom/ShapeExpression.scala
@@ -27,6 +27,13 @@ sealed trait ShapeExpression {
 object ShapeExpression {
 
   /**
+   * An empty shape for use in building up an expression iteratively.
+   *
+   * @group Constructors
+   */
+  final case object Empty extends ShapeExpression
+
+  /**
    * Ellipse contained in the rectangle defined by the two positions.
    *
    * @group Constructors

--- a/modules/math/shared/src/main/scala/gsp/math/geom/jts/JtsShapeInterpreter.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/geom/jts/JtsShapeInterpreter.scala
@@ -42,6 +42,7 @@ object JtsShapeInterpreter extends ShapeInterpreter {
 
     e match {
       // Constructors
+      case Empty              => EmptyGeometry
       case Ellipse(a, b)      => safeRectangularBoundedShape(a, b) {_.createEllipse}
       case Polygon(os)        => safePolygon(os)
       case Rectangle(a, b)    => safeRectangularBoundedShape(a, b) {_.createRectangle}

--- a/modules/math/shared/src/main/scala/gsp/math/geom/syntax/ShapeExpression.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/geom/syntax/ShapeExpression.scala
@@ -67,6 +67,12 @@ trait ToShapeExpressionOps {
 
 final class ShapeExpressionCompanionOps(val self: ShapeExpression.type) extends AnyVal {
 
+  /**
+   * An empty `ShapeExpression` with a broader type.
+   */
+  def empty: ShapeExpression =
+    ShapeExpression.Empty
+
   // Simplified constructors
 
   private def offset(p: Angle, q: Angle): Offset =
@@ -135,7 +141,7 @@ final class ShapeExpressionCompanionOps(val self: ShapeExpression.type) extends 
    * @group Constructors
    */
   def centeredRectangle(w: Angle, h: Angle): ShapeExpression =
-    Translate(ellipse(w, h), offset(-w.bisect, -h.bisect))
+    Translate(rectangle(w, h), offset(-w.bisect, -h.bisect))
 
   /**
    * Constructs an ellipse contained in a rectangle of width w and height h with

--- a/modules/testkit/shared/src/main/scala/gsp/math/geom/arb/ArbShapeExpression.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/geom/arb/ArbShapeExpression.scala
@@ -64,6 +64,9 @@ trait ArbShapeExpression {
       a <- arbitrary[Angle]
     } yield (s ⟲ a) ↗ o
 
+  val genEmpty: Gen[ShapeExpression] =
+    Gen.const(ShapeExpression.Empty)
+
   val genEllipse: Gen[ShapeExpression] =
     withPerturbation(genCenteredEllipse)
 
@@ -74,7 +77,7 @@ trait ArbShapeExpression {
     withPerturbation(genCenteredRectangle)
 
   val genShape: Gen[ShapeExpression] =
-    Gen.oneOf(genEllipse, genPolygon, genRectangle)
+    Gen.oneOf(genEmpty, genEllipse, genPolygon, genRectangle)
 
   // Not implicit.  This is a single arbitrary shape, not in any way a
   // combination of shapes, so it isn't really an "arbitrary ShapeExpression".

--- a/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosScienceAreaGeometry.scala
+++ b/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosScienceAreaGeometry.scala
@@ -23,14 +23,19 @@ object GmosScienceAreaGeometry {
   private def offsetInP(p: Angle): Offset =
     Offset(Offset.P(p), Offset.Q.Zero)
 
-  private def imagingFov(size: Angle, notch: Angle): ShapeExpression = {
+  private def imagingFov(size: Angle, corner: Angle): ShapeExpression = {
     val centerCcdWidth: Angle = 165600.mas
     val gapWidth: Angle       =   3000.mas
 
-    // `ccd` is a square with the corners cut such that each missing corner is a
-    // right isosceles triangle with the equal sides of length `notch`.
     val z   = Angle.Angle0
-    val n   = size - notch
+
+    // (size/2) + (size/2 - corner) = distance from center to any vertex
+    // Used to make a square rotated by 45 degrees with sides =
+    // sqrt(2 * ((size/2) + (size/2 - corner))^2) = sqrt(2*(size - corner)^2)
+    val n   = size - corner
+
+    // `ccd` is a square with the corners cut such that each missing corner is a
+    // right isosceles triangle with the equal sides of length `corner`.
     val ccd = ShapeExpression.centeredRectangle(size, size) ∩
                 ShapeExpression.polygonAt((z, n), (n, z), (z, -n), (-n, z))
 

--- a/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosScienceAreaGeometry.scala
+++ b/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosScienceAreaGeometry.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.geom.jts.demo
+
+import gsp.math.{ Angle, Offset }
+import gsp.math.geom._
+import gsp.math.geom.syntax.all._
+
+import gsp.math.syntax.int._
+
+/**
+ * GMOS science area geometry.
+ */
+object GmosScienceAreaGeometry {
+
+  val imaging: ShapeExpression =
+    imagingFov(330340.mas, 33840.mas)
+
+  val mos: ShapeExpression =
+    imagingFov(314240.mas, 17750.mas)
+
+  private def offsetInP(p: Angle): Offset =
+    Offset(Offset.P(p), Offset.Q.Zero)
+
+  private def imagingFov(size: Angle, notch: Angle): ShapeExpression = {
+    val centerCcdWidth: Angle = 165600.mas
+    val gapWidth: Angle       =   3000.mas
+
+    // `ccd` is a square with the corners cut such that each missing corner is a
+    // right isosceles triangle with the equal sides of length `notch`.
+    val z   = Angle.Angle0
+    val n   = size - notch
+    val ccd = ShapeExpression.centeredRectangle(size, size) ∩
+                ShapeExpression.polygonAt((z, n), (n, z), (z, -n), (-n, z))
+
+    // Detector gap at the origin.
+    val gap  = ShapeExpression.centeredRectangle(gapWidth, size)
+
+    // Offset of detector gap from the center
+    val off  = offsetInP((centerCcdWidth + gapWidth).bisect)
+
+    // There are two gaps so three disjoint CCDs.
+    ccd - (gap ↗ off) - (gap ↗ -off)
+  }
+
+  def longSlitFov(width: Angle): ShapeExpression = {
+    val h = 108000.mas
+    val g =   3200.mas
+
+    val x = width.bisect
+    val d = h + g
+
+    // Slit in three sections of length `h` separated by gaps `g`.
+    (-1 to 1).foldLeft(ShapeExpression.empty) { (e, i) =>
+      val y = h.bisect + Angle.fromMicroarcseconds(d.toMicroarcseconds * i)
+      e ∪ ShapeExpression.rectangleAt((x, y), (-x, y - h))
+    }
+  }
+
+}

--- a/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/JtsDemo.scala
@@ -22,8 +22,11 @@ import scala.jdk.CollectionConverters._
 object JtsDemo extends Frame("JTS Demo") {
 
   // Shape to display
-  val shape: ShapeExpression =
-    GmosOiwfsProbeArm.shape ⟲ 45.deg
+  val shapes: List[ShapeExpression] =
+    List(
+      GmosOiwfsProbeArm.shape ⟲ 45.deg,
+      GmosScienceAreaGeometry.imaging
+    )
 
   // Scale
   val arcsecPerPixel: Double =
@@ -73,11 +76,11 @@ object JtsDemo extends Frame("JTS Demo") {
         // distance from center in arcsec
         val das = (i * Angle.signedArcseconds.get(gridSize).toDouble).round
 
-        // Draw the labels
-        if (das != 0L) g2d.drawString(s"-$das", -dpx + 5, - halfCanvas + 10)
-        g2d.drawString(s"$das", dpx + 5, - halfCanvas + 10)
-        if (das != 0L) g2d.drawString(s"-$das", - halfCanvas + 5, -dpx - 5)
-        g2d.drawString(s"$das", - halfCanvas + 5, dpx - 5)
+        // Draw the labels (p increasing to the left, q increasing upward)
+        g2d.drawString(s"$das", -dpx + 5, - halfCanvas + 10)
+        if (das != 0L) g2d.drawString(s"-$das", dpx + 5, - halfCanvas + 10)
+        g2d.drawString(s"$das", - halfCanvas + 5, -dpx - 5)
+        if (das != 0L) g2d.drawString(s"-$das", - halfCanvas + 5, dpx - 5)
 
         // Draw the grid lines
         g2d.drawLine(-dpx, -halfCanvas, -dpx, halfCanvas)
@@ -88,9 +91,11 @@ object JtsDemo extends Frame("JTS Demo") {
       g2d.setStroke(origStroke)
 
       // Finally, draw the shape.
-      shape.eval match {
-        case jts: JtsShape => g2d.draw(jts.toAwt(arcsecPerPixel))
-        case x             => sys.error(s"Whoa unexpected shape type: $x")
+      shapes.foreach { shape =>
+        shape.eval match {
+          case jts: JtsShape => g2d.draw(jts.toAwt(arcsecPerPixel))
+          case x             => sys.error(s"Whoa unexpected shape type: $x")
+        }
       }
 
     }

--- a/modules/tests/shared/src/test/scala/gsp/math/geom/ShapeExpressionSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/geom/ShapeExpressionSpec.scala
@@ -13,7 +13,8 @@ import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
 final class ShapeExpressionSpec extends CatsSuite {
-  implicit val interpreter = gsp.math.geom.jts.interpreter.value
+  implicit val interpreter: ShapeInterpreter =
+    gsp.math.geom.jts.interpreter.value
 
   import ArbAngle._
   import ArbOffset._


### PR DESCRIPTION
Adds a `GmosScienceAreaGeometry`, fixes a couple of bugs, and adds a new `ShapeExpression.Empty`.  This is an interim PR.  Ultimately the GMOS stuff (probe arm, science area and probe range) should be moved into, presumably, `gsp-core`.