### PR TITLE
Fix test case

### DIFF
--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
@@ -94,8 +94,8 @@ final class OffsetSpec extends CatsSuite {
     // not exactly invertable because of rounding
     forAll { (o: Offset, θ: Angle) =>
       val oʹ = o.rotate(θ).rotate(-θ)
-      val (p,  q)  = Offset.microarcseconds.get(o)
-      val (pʹ, qʹ) = Offset.microarcseconds.get(oʹ)
+      val (p,  q)  = Offset.signedMicroarcseconds.get(o)
+      val (pʹ, qʹ) = Offset.signedMicroarcseconds.get(oʹ)
       assert(
         ((p - pʹ).abs <= 1) && ((q - qʹ).abs <= 1)
       )


### PR DESCRIPTION
Please accept my apologies, an `OffsetSpec` test case would fail when the two angles being compared are 0 and -1 µas (which is 1295999999999 unsigned µas).