### PR TITLE
Rename decimal angle optics

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/Angle.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Angle.scala
@@ -317,22 +317,22 @@ trait AngleOptics extends OpticsHelpers { this: Angle.type =>
   }
 
   // Exact signed angles, scaled by moving the decimal point `scale` digits to the left
-  private def signedMicroarcsecondsScaled(scale: Int): SplitMono[Angle, BigDecimal] =
+  private def signedDecimalMicroarcsecondsScaled(scale: Int): SplitMono[Angle, BigDecimal] =
     signedMicroarcseconds.imapB(_.underlying.movePointRight(scale).longValue, n => new java.math.BigDecimal(n).movePointLeft(scale))
 
   /**
    * Signed decimal milliarcseconds, exact, in [-180°, 180°).
    * @group Optics
    */
-  lazy val signedMilliarcseconds: SplitMono[Angle, BigDecimal] =
-    signedMicroarcsecondsScaled(3)
+  lazy val signedDecimalMilliarcseconds: SplitMono[Angle, BigDecimal] =
+    signedDecimalMicroarcsecondsScaled(3)
 
   /**
    * Signed decimal arcseconds, exact, in [-180°, 180°).
    * @group Optics
    */
-  lazy val signedArcseconds: SplitMono[Angle, BigDecimal] =
-    signedMicroarcsecondsScaled(6)
+  lazy val signedDecimalArcseconds: SplitMono[Angle, BigDecimal] =
+    signedDecimalMicroarcsecondsScaled(6)
 
   /**
    * Milliarcseconds, in [0, 360°).

--- a/modules/math/shared/src/main/scala/gsp/math/Offset.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Offset.scala
@@ -123,8 +123,8 @@ object Offset extends OffsetOptics {
     def angle[A]: Iso[Component[A], Angle] =
       GenIso[Component[A], Angle]
 
-    def signedArcseconds[A]: SplitMono[Component[A], BigDecimal] =
-      Angle.signedArcseconds.imapA(Component[A], _.toAngle)
+    def signedDecimalArcseconds[A]: SplitMono[Component[A], BigDecimal] =
+      Angle.signedDecimalArcseconds.imapA(Component[A], _.toAngle)
   }
 
   // P, Q types and objects defined for convenience.
@@ -139,7 +139,7 @@ object Offset extends OffsetOptics {
 
     val angle: Iso[Component[A], Angle] = Component.angle[A]
 
-    val signedArcseconds: SplitMono[Component[A], BigDecimal] = Component.signedArcseconds[A]
+    val signedDecimalArcseconds: SplitMono[Component[A], BigDecimal] = Component.signedDecimalArcseconds[A]
   }
 
   object P extends ComponentCompanion[Axis.P]
@@ -196,7 +196,7 @@ trait OffsetOptics {
     splitMonoFromAngleSplitMono(Angle.signedMicroarcseconds)
 
   /** @group Optics */
-  val signedArcseconds: SplitMono[Offset, (BigDecimal, BigDecimal)] =
-    splitMonoFromAngleSplitMono(Angle.signedArcseconds)
+  val signedDecimalArcseconds: SplitMono[Offset, (BigDecimal, BigDecimal)] =
+    splitMonoFromAngleSplitMono(Angle.signedDecimalArcseconds)
 
 }

--- a/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosOiwfsProbeArm.scala
+++ b/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/GmosOiwfsProbeArm.scala
@@ -83,14 +83,14 @@ object GmosOiwfsProbeArm {
     val t   = Offset(427520.mas.p, 101840.mas.q)
     val tʹ  = if (sideLooking) Offset.qAngle.modify(_.mirrorBy(Angle.Angle0))(t) else t
 
-    val bx  = Angle.signedArcseconds.get(StageArmLength).toDouble
+    val bx  = Angle.signedDecimalArcseconds.get(StageArmLength).toDouble
     val bxᒾ = bx*bx
 
-    val mx  = Angle.signedArcseconds.get(PickoffArmLength).toDouble
+    val mx  = Angle.signedDecimalArcseconds.get(PickoffArmLength).toDouble
     val mxᒾ = mx*mx
 
     val (x, y) =
-      Offset.signedArcseconds.get(
+      Offset.signedDecimalArcseconds.get(
         tʹ.rotate(posAngle) + guideStar - (offsetPos - ifuOffset).rotate(posAngle)
       ).bimap(x => -x.toDouble, _.toDouble)
 

--- a/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/gsp/math/geom/jts/demo/JtsDemo.scala
@@ -78,7 +78,7 @@ object JtsDemo extends Frame("JTS Demo") {
       g2d.drawLine(0, -2, 0, 2)
 
       // Pixels in each grid square.
-      val gpx = Angle.signedArcseconds.get(gridSize).toDouble / arcsecPerPixel
+      val gpx = Angle.signedDecimalArcseconds.get(gridSize).toDouble / arcsecPerPixel
 
       val origStroke = g2d.getStroke
 
@@ -92,7 +92,7 @@ object JtsDemo extends Frame("JTS Demo") {
         val dpx = (i * gpx).round.toInt
 
         // distance from center in arcsec
-        val das = (i * Angle.signedArcseconds.get(gridSize).toDouble).round
+        val das = (i * Angle.signedDecimalArcseconds.get(gridSize).toDouble).round
 
         // Draw the labels (p increasing to the left, q increasing upward)
         g2d.drawString(s"$das", -dpx + 5, - halfCanvas + 10)

--- a/modules/tests/shared/src/test/scala/gsp/math/AngleSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/AngleSpec.scala
@@ -22,8 +22,8 @@ final class AngleSpec extends CatsSuite {
   // Optics
   checkAll("microarcseconds", SplitMonoTests(Angle.microarcseconds).splitMono)
   checkAll("signedMicroarcseconds", SplitMonoTests(Angle.signedMicroarcseconds).splitMono)
-  checkAll("signedMilliarcseconds", SplitMonoTests(Angle.signedMilliarcseconds).splitMono)
-  checkAll("signedArcseconds", SplitMonoTests(Angle.signedArcseconds).splitMono)
+  checkAll("signedDecimalMilliarcseconds", SplitMonoTests(Angle.signedDecimalMilliarcseconds).splitMono)
+  checkAll("signedDecimalArcseconds", SplitMonoTests(Angle.signedDecimalArcseconds).splitMono)
   checkAll("milliarcseconds", WedgeTests(Angle.milliarcseconds).wedge)
   checkAll("arcseconds", WedgeTests(Angle.arcseconds).wedge)
   checkAll("arcminutes", WedgeTests(Angle.arcminutes).wedge)

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetPSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetPSpec.scala
@@ -19,7 +19,7 @@ final class OffsetPSpec extends CatsSuite {
   checkAll("Offset.Component[Axis.P].commutativeGroup", CommutativeGroupTests[Offset.Component[Axis.P]].commutativeGroup)
   checkAll("Offset.Component[Axis.P].order", OrderTests[Offset.Component[Axis.P]].order)
   checkAll("Offset.Component.angle[Axis.P]", IsoTests(Offset.Component.angle[Axis.P]))
-  checkAll("Offset.Component.signedArcseconds[Axis.P]", SplitMonoTests(Offset.Component.signedArcseconds[Axis.P]).splitMono)
+  checkAll("Offset.Component.signedArcseconds[Axis.P]", SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.P]).splitMono)
 
   test("Equality must be natural") {
     forAll { (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetQSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetQSpec.scala
@@ -19,7 +19,7 @@ final class OffsetQSpec extends CatsSuite {
   checkAll("Offset.Component[Axis.Q].commutativeGroup", CommutativeGroupTests[Offset.Component[Axis.Q]].commutativeGroup)
   checkAll("Offset.Component[Axis.Q].order", OrderTests[Offset.Component[Axis.Q]].order)
   checkAll("Offset.Component.angle[Axis.Q]", IsoTests(Offset.Component.angle[Axis.Q]))
-  checkAll("Offset.Component.signedArcseconds[Axis.Q]", SplitMonoTests(Offset.Component.signedArcseconds[Axis.Q]).splitMono)
+  checkAll("Offset.Component.signedArcseconds[Axis.Q]", SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.Q]).splitMono)
 
   test("Equality must be natural") {
     forAll { (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
@@ -25,7 +25,7 @@ final class OffsetSpec extends CatsSuite {
   checkAll("Axis.QAngle", LensTests(Offset.qAngle))
   checkAll("Offset.microarcseconds", SplitMonoTests(Offset.microarcseconds).splitMono)
   checkAll("Offset.signedMicroarcseconds", SplitMonoTests(Offset.signedMicroarcseconds).splitMono)
-  checkAll("Offset.signedArcseconds", SplitMonoTests(Offset.signedArcseconds).splitMono)
+  checkAll("Offset.signedArcseconds", SplitMonoTests(Offset.signedDecimalArcseconds).splitMono)
 
   test("Equality must be natural") {
     forAll { (a: Offset, b: Offset) =>
@@ -79,7 +79,7 @@ final class OffsetSpec extends CatsSuite {
       val expected = Offset(pʹ, qʹ)
       val actual = Offset(p, q).rotate(θ)
       if (Eq[Offset].neqv(expected, actual)) {
-        val t = s"Offset(${Offset.P.signedArcseconds.get(p)}, ${Offset.Q.signedArcseconds.get(q)}).rotate(${θ.toSignedDoubleDegrees}º)"
+        val t = s"Offset(${Offset.P.signedDecimalArcseconds.get(p)}, ${Offset.Q.signedDecimalArcseconds.get(q)}).rotate(${θ.toSignedDoubleDegrees}º)"
 
         fail(
           s"""$t


### PR DESCRIPTION
A minor renaming to address an issue with `Angle` optics that had been bugging me.  In particular `Angle.arcseconds` is a `Wedge[Angle, Int]` but `Angle.signedArcseconds` was a `SplitMono[Angle, BigDecimal]`.  The names would imply that the only difference should be whether or not the value produced by `get` is signed.

I think a `Wedge[Angle, Int]` for signed arcseconds is probably not very useful but could be defined if needed.  Instead I renamed `signedArcseconds` to `signedDecimalArcseconds`.