### PR TITLE
Improvements to svg generation to better support Safari

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.sonatypeRepo("public")
 
-addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.2.2")
+addSbtPlugin("edu.gemini"         % "sbt-gsp"                  % "0.2.3")
 addSbtPlugin("com.geirsson"       % "sbt-ci-release"           % "1.5.3")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.1.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
Ideally we would do transformation at the svg level but Safari doesn't support them, but we can apply them to as svg group underneath.
This PR updates the generator to include that group