### PR TITLE
Migrate twilight calculations from OCS.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val kindProjectorVersion        = "0.10.3"
 lazy val monocleVersion              = "2.0.5"
 lazy val catsTestkitScalaTestVersion = "1.0.1"
 lazy val scalaJavaTimeVersion        = "2.0.0"
+lazy val geminiLocalesVersion        = "0.5.0"
 lazy val jtsVersion                  = "0.0.9"
 lazy val svgdotjsVersion             = "0.0.1"
 lazy val newType                     = "0.4.4"
@@ -45,6 +46,7 @@ lazy val math = crossProject(JVMPlatform, JSPlatform)
   .jsSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion,
+      "edu.gemini"        %%% "gemini-locales"  % geminiLocalesVersion,
       "edu.gemini"        %%% "gpp-svgdotjs"    % svgdotjsVersion
     )
   )

--- a/modules/math/shared/src/main/scala/gsp/math/Coordinates.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Coordinates.scala
@@ -9,58 +9,58 @@ import gsp.math.optics.Format
 import gsp.math.syntax.all._
 import monocle.Lens
 import monocle.macros._
-import scala.math.{ sin, cos, atan2, sqrt }
+import scala.math.{ atan2, cos, sin, sqrt }
 
 /** A point in the sky, given right ascension and declination. */
 final case class Coordinates(ra: RightAscension, dec: Declination) {
 
   /**
-   * Offset these `Coordinates` by the given deltas, and indicate whether the declination crossed
-   * a pole; if so the right ascension will have been flipped 180°.
-   * @group Operations
-   */
+    * Offset these `Coordinates` by the given deltas, and indicate whether the declination crossed
+    * a pole; if so the right ascension will have been flipped 180°.
+    * @group Operations
+    */
   def offsetWithCarry(dRA: HourAngle, dDec: Angle): (Coordinates, Boolean) =
     dec.offset(dDec) match {
-      case (decʹ, false) => (Coordinates(ra.offset(dRA),      decʹ), false)
+      case (decʹ, false) => (Coordinates(ra.offset(dRA), decʹ), false)
       case (decʹ, true)  => (Coordinates(ra.flip.offset(dRA), decʹ), true)
     }
 
   /**
-   * Offset these `Coordinates` by the given deltas. If the declination crossed a pole the right
-   * ascension will have been flipped 180°.
-   * @group Operations
-   */
+    * Offset these `Coordinates` by the given deltas. If the declination crossed a pole the right
+    * ascension will have been flipped 180°.
+    * @group Operations
+    */
   def offset(dRA: HourAngle, dDec: Angle): Coordinates =
     offsetWithCarry(dRA, dDec)._1
 
   /**
-   * Compute the offset between points, such that `a offset (a diff b) = b`.
-   * @group Operations
-   */
+    * Compute the offset between points, such that `a offset (a diff b) = b`.
+    * @group Operations
+    */
   def diff(c: Coordinates): (HourAngle, Angle) =
     (c.ra.toHourAngle - ra.toHourAngle, c.dec.toAngle - dec.toAngle)
 
   /**
-   * Angular distance from `this` to `that`, always a positive angle in [0, 180]). Approximate.
-   * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
-   */
+    * Angular distance from `this` to `that`, always a positive angle in [0, 180]). Approximate.
+    * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
+    */
   def angularDistance(that: Coordinates): Angle = {
     val φ1 = this.dec.toAngle.toDoubleRadians
     val φ2 = that.dec.toAngle.toDoubleRadians
     val Δφ = (that.dec.toAngle - this.dec.toAngle).toDoubleRadians
-    val Δλ = (that.ra.toAngle  - this.ra.toAngle) .toDoubleRadians
+    val Δλ = (that.ra.toAngle - this.ra.toAngle).toDoubleRadians
     val a  = sin(Δφ / 2) * sin(Δφ / 2) +
-             cos(φ1)     * cos(φ2)     *
-             sin(Δλ / 2) * sin(Δλ / 2)
+      cos(φ1) * cos(φ2) *
+        sin(Δλ / 2) * sin(Δλ / 2)
     Angle.fromDoubleRadians(2 * atan2(sqrt(a), sqrt(1 - a)))
   }
 
   /**
-   * Interpolate between `this` and `that` at a position specified by `f`, where `0.0` is `this`,
-   * `1.0` is `other`, and `0.5` is halfway along the great circle connecting them. Note that this
-   * computation is undefined where `f` is `NaN` or `Infinity`. Approximate.
-   * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
-   */
+    * Interpolate between `this` and `that` at a position specified by `f`, where `0.0` is `this`,
+    * `1.0` is `other`, and `0.5` is halfway along the great circle connecting them. Note that this
+    * computation is undefined where `f` is `NaN` or `Infinity`. Approximate.
+    * @see Algorithm at [[http://www.movable-type.co.uk/scripts/latlong.html Movable Type Scripts]].
+    */
   def interpolate(that: Coordinates, f: Double): Coordinates = {
     val δ = angularDistance(that).toDoubleRadians
     if (δ === 0) this
@@ -92,12 +92,14 @@ final case class Coordinates(ra: RightAscension, dec: Declination) {
 
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
 object Coordinates extends CoordinatesOptics {
 
-  /* @group Constructors */ val Zero:      Coordinates = Coordinates(RA.Zero, Dec.Zero)
-  /* @group Constructors */ val SouthPole: Coordinates = Coordinates(RA.Zero, Dec.Min)
-  /* @group Constructors */ val NorthPole: Coordinates = Coordinates(RA.Zero, Dec.Max)
+  /* @group Constructors */
+  val Zero: Coordinates      = Coordinates(RA.Zero, Dec.Zero)
+  /* @group Constructors */
+  val SouthPole: Coordinates = Coordinates(RA.Zero, Dec.Min)
+  /* @group Constructors */
+  val NorthPole: Coordinates = Coordinates(RA.Zero, Dec.Max)
 
   def fromRadians(ra: Double, dec: Double): Option[Coordinates] =
     Declination.fromRadians(dec).map(Coordinates(RA.fromRadians(ra), _))
@@ -118,12 +120,14 @@ object Coordinates extends CoordinatesOptics {
 trait CoordinatesOptics { this: Coordinates.type =>
 
   /**
-   * Format as a String like "17 57 48.49803 +04 41 36.2072".
-   * @group Optics
-   */
+    * Format as a String like "17 57 48.49803 +04 41 36.2072".
+    * @group Optics
+    */
   val fromHmsDms: Format[String, Coordinates] = Format(
     CoordinateParsers.coordinates.parseExact,
-    cs => s"${RightAscension.fromStringHMS.reverseGet(cs.ra)} ${Declination.fromStringSignedDMS.reverseGet(cs.dec)}"
+    cs =>
+      s"${RightAscension.fromStringHMS.reverseGet(cs.ra)} ${Declination.fromStringSignedDMS
+        .reverseGet(cs.dec)}"
   )
 
   /** @group Optics */

--- a/modules/math/shared/src/main/scala/gsp/math/Place.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Place.scala
@@ -7,9 +7,10 @@ import cats.Eq
 import cats.Show
 import monocle.Lens
 import monocle.macros.GenLens
+import java.time.ZoneId
 
 /** A point on Earth, given latitude, longitude and altitude in m above sea level. */
-final case class Place(latitude: Lat, longitude: Lon, altitude: Double)
+final case class Place(latitude: Lat, longitude: Lon, altitude: Double, zoneId: ZoneId)
 
 object Place {
 
@@ -30,4 +31,8 @@ object Place {
   /** @group Optics */
   val altitude: Lens[Place, Double] =
     GenLens[Place](_.altitude)
+
+  /** @group Optics */
+  val zoneId: Lens[Place, ZoneId] =
+    GenLens[Place](_.zoneId)
 }

--- a/modules/math/shared/src/main/scala/gsp/math/skycalc/ImprovedSkyCalcMethods.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/skycalc/ImprovedSkyCalcMethods.scala
@@ -3,6 +3,8 @@
 
 package gsp.math.skycalc
 
+import gsp.math.JulianDate
+
 import java.time.LocalTime
 import java.time.Instant
 import java.time.ZonedDateTime
@@ -24,18 +26,18 @@ trait ImprovedSkyCalcMethods {
   protected val PI_OVER_2 = 1.57079632679490 // From Abramowitz & Stegun
 
   protected val ARCSEC_IN_RADIAN = 206264.8062471
-  protected val DEG_IN_RADIAN    = 57.2957795130823
+  val DEG_IN_RADIAN              = 57.2957795130823
   protected val HRS_IN_RADIAN    = 3.819718634205
   protected val KMS_AUDAY        = 1731.45683633 // km per sec in 1 AU/day
 
   protected val SPEED_OF_LIGHT = 299792.458 // in km per sec ... exact.
 
-  protected val J2000 = 2451545.0 // Julian date at standard epoch
+  protected val J2000 = JulianDate.J2000.toDouble
 
   protected val SEC_IN_DAY = 86400.0
   protected val FLATTEN    = 0.003352813 // flattening of earth, 1/298.257
 
-  protected val EQUAT_RAD = 6378137.0 // equatorial radius of earth, meters
+  val EQUAT_RAD = 6378137.0 // equatorial radius of earth, meters
 
   protected val ASTRO_UNIT = 1.4959787066e11 // 1 AU in meters
 
@@ -873,7 +875,7 @@ trait ImprovedSkyCalcMethods {
     var inter  = 0L
     var jd     = .0
     var jdfrac = .0
-    val date = instant.atZone(ZoneOffset.UTC)
+    val date   = instant.atZone(ZoneOffset.UTC)
     if (
       (date.getYear <= 1900) | (date.getYear >= 2100)
     ) //        printf("Date out of range.  1900 - 2100 only.\n");
@@ -889,7 +891,8 @@ trait ImprovedSkyCalcMethods {
     inter = (30.6001 * (date.getMonthValue + mo1)).toLong
     jdint = jdint + inter + date.getDayOfMonth + jdzpt
     jd = jdint.toDouble
-    jdfrac = date.getHour / 24.0 + date.getMinute / 1440.0 + (date.getSecond + date.getNano / NanosPerSecond) / SEC_IN_DAY
+    jdfrac =
+      date.getHour / 24.0 + date.getMinute / 1440.0 + (date.getSecond + date.getNano / NanosPerSecond) / SEC_IN_DAY
     if (jdfrac < 0.5) {
       jdint -= 1
       jdfrac = jdfrac + 0.5

--- a/modules/math/shared/src/main/scala/gsp/math/skycalc/SunCalc.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/skycalc/SunCalc.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.skycalc
+
+import cats.implicits._
+import gsp.math.JulianDate
+
+trait SunCalc extends ImprovedSkyCalcMethods {
+  protected def lst(jd: JulianDate, longit: Double): Double =
+    lst(jd.toDouble, longit)
+
+  /**
+    * returns altitude(degr) for dec, ha, lat (decimal degr, hr, degr)
+    *
+    * @param dec target declination in degrees
+    * @param ha  the hour angle in hours
+    * @param lat the observer's latitude in degrees
+    * @return the altitude in degrees
+    */
+  protected def altit(dec: Double, ha: Double, lat: Double): Double = {
+    val az     = new DoubleRef()
+    val parang = new DoubleRef()
+    return altit(dec, ha, lat, az, parang)
+  }
+
+  /**
+    * returns jd at which sun is at a given
+    * altitude, given jdguess as a starting point. Uses
+    * low-precision sun, which is plenty good enough.
+    */
+  protected def jd_sun_alt(
+    alt:      Double,
+    jdguess0: JulianDate,
+    lat:      Double,
+    longit:   Double
+  ): Option[JulianDate] = {
+    val del = 0.002
+
+    var jdguess = jdguess0
+
+    /* first guess */
+    var sun = lpsun(jdguess)
+    var ra  = sun._1
+    var dec = sun._2
+
+    val ha   = lst(jdguess, longit) - ra
+    val alt2 = altit(dec, ha, lat)
+    jdguess = JulianDate.fromDoubleApprox(jdguess.toDouble + del)
+
+    sun = lpsun(jdguess)
+    ra = sun._1
+    dec = sun._2
+
+    var alt3  = altit(dec, lst(jdguess, longit) - ra, lat)
+    var err   = alt3 - alt
+    val deriv = (alt3 - alt2) / del
+    var i     = 0
+
+    while ((Math.abs(err) > 0.1) && (i < 10)) {
+      jdguess = JulianDate.fromDoubleApprox(jdguess.toDouble - err / deriv)
+      sun = lpsun(jdguess)
+      ra = sun._1
+      dec = sun._2
+
+      alt3 = altit(dec, lst(jdguess, longit) - ra, lat)
+      err = alt3 - alt
+      i += 1
+    }
+    // If None: sunrise, set, or twilight calculation not converging.
+    jdguess.some.filter(_ => i < 9)
+  }
+
+  /**
+    * Returns hour angle at which object at dec is at altitude alt.
+    * If object is never at this altitude, signals with special
+    * return values 1000 (always higher) and -1000 (always lower).
+    */
+  protected def ha_alt(dec0: Double, lat0: Double, alt: Double): Double = {
+    var dec = dec0
+    var lat = lat0
+
+    var min_max: Array[Double] = null
+    try min_max = min_max_alt(lat, dec)
+    catch {
+      case _: Exception =>
+        return 1000.0
+    }
+    if (alt < min_max(0)) return 1000.0  // flag value - always higher than asked
+    if (alt > min_max(1)) return -1000.0 // flag for object always lower than asked
+    dec = PI_OVER_2 - dec / DEG_IN_RADIAN
+    lat = PI_OVER_2 - lat / DEG_IN_RADIAN
+    val coalt = PI_OVER_2 - alt / DEG_IN_RADIAN
+    val x     = (Math.cos(coalt) - Math.cos(dec) * Math.cos(lat)) / (Math.sin(dec) * Math.sin(lat))
+    if (Math.abs(x) <= 1.0)
+      Math.acos(x) * HRS_IN_RADIAN
+    else
+      throw new RuntimeException("Error in ha_alt ... acos(>1).")
+  }
+
+  /**
+    * Computes minimum and maximum altitude for a given dec and
+    * latitude.
+    *
+    * @return 2 element double array where element 0 is the min altitude
+    *         and element 1 is the max altitude
+    */
+  protected def min_max_alt(lat0: Double, dec0: Double): Array[Double] = {
+    var lat = lat0
+    var dec = dec0
+
+    var min = 0.0
+    var max = 0.0
+    lat = lat / DEG_IN_RADIAN
+    dec = dec / DEG_IN_RADIAN
+    var x   = Math.cos(dec) * Math.cos(lat) + Math.sin(dec) * Math.sin(lat)
+    if (Math.abs(x) <= 1.0) max = Math.asin(x) * DEG_IN_RADIAN
+    else
+      throw new RuntimeException("Error in min_max_alt -- arcsin(>1)")
+    x = Math.sin(dec) * Math.sin(lat) - Math.cos(dec) * Math.cos(lat)
+    if (Math.abs(x) <= 1.0) min = Math.asin(x) * DEG_IN_RADIAN
+    else
+      throw new RuntimeException("Error in min_max_alt -- arcsin(>1)")
+    Array[Double](min, max)
+  }
+
+  /**
+    * Low precision sun.
+    *
+    * @return Coordinates in (Hours, Degress)
+    */
+  protected def lpsun(jd: JulianDate): (Double, Double) = {
+    val n       = jd.toDouble - JulianDate.J2000.toDouble
+    val L       = 280.460 + 0.9856474 * n
+    val g       = (357.528 + 0.9856003 * n) / DEG_IN_RADIAN
+    val lambda  = (L + 1.915 * Math.sin(g) + 0.020 * Math.sin(2.0 * g)) / DEG_IN_RADIAN
+    val epsilon = (23.439 - 0.0000004 * n) / DEG_IN_RADIAN
+    val x       = Math.cos(lambda)
+    val y       = Math.cos(epsilon) * Math.sin(lambda)
+    val z       = Math.sin(epsilon) * Math.sin(lambda)
+    val ra      = atan_circ(x, y) * HRS_IN_RADIAN
+    val dec     = Math.asin(z) * DEG_IN_RADIAN
+    (ra, dec)
+  }
+
+}

--- a/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightBoundType.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightBoundType.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.skycalc
+
+import cats._
+
+/**
+  * Definition for how the range from sunset to sunrise should be defined for
+  * a night.  There are various standard options for definition where the night
+  * begins and ends which are represented as static constants in side this
+  * class.
+  */
+sealed abstract class TwilightBoundType(val name: String, val horizonAngle: Double)
+
+object TwilightBoundType {
+  case object Official     extends TwilightBoundType("Official", 50.0 / 60.0)
+  case object Civil        extends TwilightBoundType("Civil", 6.0)
+  case object Nautical     extends TwilightBoundType("Nautical", 12.0)
+  case object Astronomical extends TwilightBoundType("Astronomical", 18.0)
+
+  val all: List[TwilightBoundType] = List(Official, Civil, Nautical, Astronomical)
+
+  /** @group Typeclass Instances */
+  implicit val TwilightBoundTypeEqual: Eq[TwilightBoundType] = Eq.fromUniversalEquals
+
+  /** @group Typeclass Instances */
+  implicit val TwilightBoundTypeShow: Show[TwilightBoundType] = Show.show(_.name)
+}

--- a/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightCalc.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightCalc.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.skycalc
+
+import cats.implicits._
+import gsp.math.JulianDate
+import gsp.math.Place
+import java.time.Instant
+import java.time.LocalDate
+
+trait TwilightCalc extends SunCalc {
+
+  /** Compute start and end of night for a particular date and place.
+    *
+    * The night will be bounded by twilight as defined by
+    * [[gsp.math.skycalc.TwilightBoundType]]. It will be the night that starts
+    * on the given date and ends on the following day.
+    *
+    * @param boundType twilight bound type to use
+    * @param date date when the night starts
+    * @param place place on Earth
+    *
+    * @return A tuple of [[java.time.Instant]]s containing sunset and sunrise
+    * respectively, or None if there's no sunset or sunrise for the
+    * provided parameters.
+    */
+  def calculate(
+    boundType: TwilightBoundType,
+    date:      LocalDate,
+    place:     Place
+  ): Option[(Instant, Instant)] = {
+    val nextMidnight = date.atStartOfDay(place.zoneId).plusDays(1)
+    val jdmid        = JulianDate.ofInstant(nextMidnight.toInstant)
+
+    // Sunrise/set take altitude into account whereas the twilights don't.
+    //
+    // "The various twilights (6,12,18) describe how bright the sky is, and this does not depend on the altitude of
+    // the observer, however, the time of sunrise and sunset does.  For example, consider Hilo and Maunakea.  The
+    // sky brightness above them is the same, while the time when they see the sun dip below the horizon is not"
+    // -- Andrew Stephens 2017-11-14
+
+    val angle: Double = boundType match {
+      case TwilightBoundType.Official =>
+        // Horizon geometric correction from p. 24 of the Skycalc manual: sqrt(2 * elevation / Re) (radians)
+        boundType.horizonAngle + Math.sqrt(
+          2.0 * place.altitude / TwilightCalc.EQUAT_RAD
+        ) * TwilightCalc.DEG_IN_RADIAN
+      case _                          => boundType.horizonAngle
+    }
+
+    calcTimes(angle, jdmid, place)
+  }
+
+  private def calcTimes(
+    angle: Double,
+    jdmid: JulianDate,
+    place: Place
+  ): Option[(Instant, Instant)] = { // (Start, End)
+    val (rasun, decsun) = lpsun(jdmid)
+
+    val lat    = place.latitude.toAngle.toSignedDoubleDegrees
+    val longit = -(place.longitude.toSignedDoubleDegrees / 15.0) // skycalc wants hours
+
+    val hasunset = ha_alt(decsun, lat, -angle)
+    if (hasunset > 900.0) // flag for never sets
+      none                // Sun up all night
+    else if (hasunset < -900.0)
+      none                // Sun down all day
+    else {
+      val stmid = lst(jdmid, longit)
+      // initial guess
+      var tmp   = jdmid.toDouble + adj_time(rasun + hasunset - stmid) / 24.0
+      // more accurate
+      jd_sun_alt(-angle, JulianDate.fromDoubleApprox(tmp), lat, longit).flatMap { jdSet =>
+        // initial guess
+        tmp = jdmid.toDouble + adj_time(rasun - hasunset - stmid) / 24.0
+        // more accurate
+        jd_sun_alt(-angle, JulianDate.fromDoubleApprox(tmp), lat, longit).map { jdRise =>
+          (jdSet.toInstant, jdRise.toInstant)
+        }
+      }
+    }
+  }
+}
+
+object TwilightCalc extends TwilightCalc

--- a/modules/math/shared/src/main/scala/gsp/math/syntax/Prism.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/syntax/Prism.scala
@@ -6,7 +6,6 @@ package gsp.math.syntax
 import gsp.math.optics.Format
 import monocle.Prism
 
-@SuppressWarnings(Array("org.wartremover.warts.Null"))
 final class PrismOps[A, B](val self: Prism[A, B]) extends AnyVal {
 
   /** Weaken to Format. */
@@ -14,7 +13,6 @@ final class PrismOps[A, B](val self: Prism[A, B]) extends AnyVal {
     Format.fromPrism(self)
 
   /** Like getOption, but throws IllegalArgumentException on failure. */
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def unsafeGet(a: A): B =
     asFormat.unsafeGet(a)
 

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbPlace.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbPlace.scala
@@ -3,28 +3,35 @@
 
 package gsp.math.arb
 
-import gsp.math.{ Angle, Declination, Place }
+import gsp.math.{ Angle, Lat, Lon, Place }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen._
+import java.time.ZoneId
 
 trait ArbPlace {
   import ArbAngle._
   import ArbDeclination._
+  import ArbTime._
+
+  private val MinAltitude: Double = 0.0
+  private val MaxAltitude: Double = 8000.0
+
+  val genEarthAlt: Gen[Double] =
+    Gen.chooseNum(MinAltitude, MaxAltitude)
 
   implicit val arbPlace: Arbitrary[Place] =
     Arbitrary {
       for {
-        lat <- arbitrary[Declination]
-        lon <- arbitrary[Angle]
-        alt <- arbitrary[Double]
-      } yield Place(lat, lon, alt)
+        lat    <- arbitrary[Lat]
+        lon    <- arbitrary[Lon]
+        alt    <- genEarthAlt
+        zoneId <- arbitrary[ZoneId]
+      } yield Place(lat, lon, alt, zoneId)
     }
 
   implicit val cogCoordinates: Cogen[Place] =
-    Cogen[(Declination, Angle, Double)].contramap(loc =>
-      (loc.latitude, loc.longitude, loc.altitude)
-    )
+    Cogen[(Lat, Angle, Double)].contramap(loc => (loc.latitude, loc.longitude, loc.altitude))
 }
 
 object ArbPlace extends ArbPlace

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbTwilightBoundType.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbTwilightBoundType.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.arb
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import gsp.math.skycalc.TwilightBoundType
+
+trait ArbTwilightBoundType {
+  val genTwilightBoundType: Gen[TwilightBoundType] =
+    oneOf(TwilightBoundType.all)
+
+  implicit val arbTwilightBoundType: Arbitrary[TwilightBoundType] =
+    Arbitrary(genTwilightBoundType)
+
+  implicit val cogTwilightBoundType: Cogen[TwilightBoundType] =
+    Cogen[String].contramap(_.name)
+}
+
+object ArbTwilightBoundType extends ArbTwilightBoundType

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/package.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/package.scala
@@ -11,7 +11,6 @@ package object arb {
   implicit class MoreGenOps[A](g: Gen[A]) {
 
     /** Like `retryUntil` but retries until the specified PartialFunction is defined. */
-    @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     def collectUntil[B](f: PartialFunction[A, B]): Gen[B] =
       g.map(a => f.lift(a)).retryUntil(_.isDefined).map(_.get)
 
@@ -37,6 +36,5 @@ package object arb {
     def pure[A](a: A): Gen[A] =
       Gen.const(a)
   }
-
 
 }

--- a/modules/tests/jvm/src/test/scala/edu/gemini/skycalc/TwilightBoundedNightTest.java
+++ b/modules/tests/jvm/src/test/scala/edu/gemini/skycalc/TwilightBoundedNightTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+ * For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package edu.gemini.skycalc;
+
+import jsky.util.DateUtil;
+
+import java.util.TimeZone;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+import java.util.Calendar;
+import gsp.math.Place;
+
+/**
+  * This class exists purely for testing purposes.
+  * It provides the same functionality as {gsp.math.skycalc.TwilightCalc},
+  * but using the Java implementation of ImprovedSkyCalcMethods, so that
+  * its results can be compared against its Scala version.
+  *
+  * Must be in edu.gemini.skycalc package to be able to access ImprovedSkyCalcMethods
+  * protected members.
+  */
+public final class TwilightBoundedNightTest {
+    private static final Logger LOG = Logger.getLogger(TwilightBoundedNightTest.class.getName());
+
+    /**
+     * Creates a {@link Night} bounded by twilight for the specified date.
+     * It will be the night that starts on that date and ends on the following
+     * day.
+     *
+     * @param type definition of twilight to use (how far below the horizon in
+     * the west that the sun must be before night starts, and how far below
+     * in the east before night ends)
+     *
+     * @param date day of month (where the first day is 1)
+     * @param month month (use the Calendar constants -- in other words
+     * January is 0 not 1)
+     * @param year year of interest (AD)
+     *
+     * @param place the place in the world
+     *
+     * @return TwilightBoundedNightTest starting on the specified date
+     */
+    public static TwilightBoundedNightTest forDate(gsp.math.skycalc.TwilightBoundType type, int date, int month, int year, Place place) {
+
+        Calendar c = Calendar.getInstance(TimeZone.getTimeZone(place.zoneId()));
+
+        // Set to midnight on that date
+        c.set(Calendar.YEAR, year);
+        c.set(Calendar.MONTH, month);
+        c.set(Calendar.DATE, date);
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+
+        return new TwilightBoundedNightTest(type, c.getTimeInMillis(), place);
+    }
+
+    /**
+     * Creates a {@link Night} bounded by twilight, depending upon the
+     * specified definition of twilight.
+     *
+     * @param type definition of twilight to use (how far below the horizon in
+     * the west that that the sun must be before night starts, and how far
+     * below in the east before night ends)
+     *
+     * @param time time of interest; if during a night local time, the night
+     * returned will be that same night, if during the day local time, it
+     * will be the night that starts on that day and ends on the following
+     * day
+     *
+     * @param place the place in the world
+     */
+    public static TwilightBoundedNightTest forTime(gsp.math.skycalc.TwilightBoundType type, long time, Place place) {
+        TwilightBoundedNightTest tonight;
+        tonight = new TwilightBoundedNightTest(type, time, place);
+
+        // If we're in the time from the dusk (inclusive) to midnight
+        // (exclusive), return the current night
+        if (tonight.includes(time)) return tonight;
+
+        // A night sits between two days.  It starts on one day and ends on the
+        // next day.  TwilightBoundedNight will use the time to get a date,
+        // for example October 9.  So from midnight local time on the 9th of
+        // October to 11:59:59 PM the night it constructs is the night of
+        // October 9/10.
+
+        // So it is possible that the current time is during the night from
+        // October 8/9. In other words, the time is between midnight and dawn.
+        // So construct "yesterday night" and check.
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(place.zoneId()));
+        cal.setTimeInMillis(time);
+        cal.add(Calendar.DAY_OF_YEAR, -1);
+
+        long timeYesterday = cal.getTimeInMillis();
+        TwilightBoundedNightTest yesterdayNight;
+        yesterdayNight = new TwilightBoundedNightTest(type, timeYesterday, place);
+        if (yesterdayNight.includes(time)) return yesterdayNight;
+
+        // Okay, the current time is during the day so return the night that
+        // is coming.
+        return tonight;
+    }
+
+    private gsp.math.skycalc.TwilightBoundType _type;
+    private Place _place;
+    private long _start;
+    private long _end;
+
+    /**
+     * Creates a {@link Night} bounded by twilight, depending upon the
+     * specified definition of twilight.
+     *
+     * @param type definition of twilight to use (how far below the horizon in
+     * the west that that the sun must be before night starts, and how far
+     * below in the east before night ends)
+     *
+     * @param time time of interest, which is only used to obtain the day;
+     * midnight and 11:59:59 PM work will both yield the same result--a Night
+     * configured for the night beginning on the date contained in
+     * <code>time</code> in the timezone specified in <code>desc</code>
+     *
+     * @param place the place in the world
+     */
+    public TwilightBoundedNightTest(gsp.math.skycalc.TwilightBoundType type, long time, Place place) {
+        _type = type;
+        _place = place;
+
+        Calendar c = Calendar.getInstance(TimeZone.getTimeZone(place.zoneId()));
+        c.setTimeInMillis(time);
+
+        // Set to midnight.
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        c.add(Calendar.DAY_OF_YEAR, 1);
+
+        // Get sunset.
+        final JulianDate jdmid = new JulianDate(c.getTimeInMillis());
+
+        // Sunrise/set take altitude into account whereas the twilights don't.
+        //
+        // "The various twilights (6,12,18) describe how bright the sky is, and this does not depend on the altitude of
+        // the observer, however, the time of sunrise and sunset does.  For example, consider Hilo and Maunakea.  The
+        // sky brightness above them is the same, while the time when they see the sun dip below the horizon is not"
+        // -- Andrew Stephens 2017-11-14
+
+        final double angle;
+        if(type == gsp.math.skycalc.TwilightBoundType.Official$.MODULE$)
+            // Horizon geometric correction from p. 24 of the Skycalc manual: sqrt(2 * elevation / Re) (radians)
+            angle = type.horizonAngle() + Math.sqrt(2.0 * place.altitude() / ImprovedSkyCalcMethods.EQUAT_RAD) *
+                    ImprovedSkyCalcMethods.DEG_IN_RADIAN;
+        else angle = type.horizonAngle();
+        _calcTimes(angle, jdmid, place);
+    }
+
+    private void _calcTimes(double angle, JulianDate jdmid, Place place) {
+        Coordinates sun = ImprovedSkyCalcMethods.lpsun(jdmid);
+        double rasun  = sun.getRaDeg();
+        double decsun = sun.getDecDeg();
+
+        double lat    =   place.latitude().toAngle().toSignedDoubleDegrees();
+        double longit = -(place.longitude().toSignedDoubleDegrees() / 15.0); // skycalc wants hours
+
+        double hasunset = ImprovedSkyCalcMethods.ha_alt(decsun, lat, -angle);
+
+        if (hasunset > 900.) {  // flag for never sets
+            LOG.log(Level.WARNING, "Sun up all night on: " + jdmid.toDate());
+            return;
+        }
+
+        if (hasunset < -900.) {
+            LOG.log(Level.WARNING, "Sun down all day on: " + jdmid.toDate());
+            return;
+        }
+
+        double stmid = ImprovedSkyCalcMethods.lst(jdmid, longit);
+
+        // initial guess
+        double tmp = jdmid.toDouble() + ImprovedSkyCalcMethods.adj_time(rasun + hasunset-stmid)/24.;
+        JulianDate jdset = new JulianDate(tmp);
+
+        // more accurate
+        jdset = ImprovedSkyCalcMethods.jd_sun_alt(-angle, jdset, lat, longit);
+        if (jdset == null) {
+            LOG.log(Level.WARNING, "Sun doesn't set on: " + jdmid.toDate());
+            return;
+        }
+
+        _start = jdset.toTimestamp();
+
+        // initial guess
+        tmp = jdmid.toDouble() + ImprovedSkyCalcMethods.adj_time(rasun - hasunset-stmid)/24.;
+        JulianDate jdrise = new JulianDate(tmp);
+
+        // more accurate
+        jdrise = ImprovedSkyCalcMethods.jd_sun_alt(-angle, jdrise, lat, longit);
+        if (jdrise == null) {
+            LOG.log(Level.WARNING, "Sun doesn't rise on: " + jdmid.toDate());
+            return;
+        }
+
+        _end = jdrise.toTimestamp();
+    }
+
+    public gsp.math.skycalc.TwilightBoundType getType() {
+        return _type;
+    }
+
+    public Place getPlace() {
+        return _place;
+    }
+
+    public long getStartTime() {
+        return _start;
+    }
+
+    public long getEndTime() {
+        return _end;
+    }
+
+    /** Start time rounded to the nearest minute in the given timezone. */
+    public long getStartTimeRounded(TimeZone zone) {
+        return DateUtil.roundToNearestMinute(_start, zone);
+    }
+
+    /** End time rounded to the nearest minute in the given timezone. */
+    public long getEndTimeRounded(TimeZone zone) {
+        return DateUtil.roundToNearestMinute(_end, zone);
+    }
+
+    public long getTotalTime() {
+        return _end - _start;
+    }
+
+    public boolean includes(long time) {
+        return (_start <= time) && (time < _end);
+    }
+}

--- a/modules/tests/jvm/src/test/scala/gsp/math/skycalc/TwilightCalcSpecJVM.scala
+++ b/modules/tests/jvm/src/test/scala/gsp/math/skycalc/TwilightCalcSpecJVM.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.skycalc
+
+import weaver._
+import weaver.scalacheck._
+
+import cats._
+import cats.implicits._
+import gsp.math.skycalc.TwilightCalc
+import java.time.LocalDate
+import gsp.math.Place
+import gsp.math.arb.ArbTime._
+import gsp.math.arb.ArbPlace._
+import gsp.math.arb.ArbTwilightBoundType._
+import edu.gemini.skycalc.TwilightBoundedNightTest
+import java.time.Instant
+import org.scalactic.Tolerance
+
+object TwilightCalcSpecJVM extends SimpleIOSuite with IOCheckers with Tolerance {
+
+  implicit val showLocalDate: Show[LocalDate] = Show.fromToString
+  implicit val InstantEq: Eq[Instant]         = Eq.fromUniversalEquals
+
+  simpleTest("TwilightCalcSpec: Arbitrary sky calculations") {
+    forall { (boundType: TwilightBoundType, localDate: LocalDate, place: Place) =>
+      val (start, end) = TwilightCalc
+        .calculate(boundType, localDate, place)
+        .map(_.bimap(_.toEpochMilli, _.toEpochMilli))
+        .getOrElse((0L, 0L))
+      val tbn          =
+        TwilightBoundedNightTest.forDate(boundType,
+                                         localDate.getDayOfMonth,
+                                         localDate.getMonthValue - 1,
+                                         localDate.getYear,
+                                         place
+        )
+
+      // The use of a different JulianDate throughout the calculations produces a very slight difference,
+      // therefore we allow a couple of milliseconds of tolerance.
+      assert((start +- 2).isWithin(tbn.getStartTime))
+        .and(assert((end +- 2).isWithin(tbn.getEndTime)))
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/gsp/math/CoordinatesSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/CoordinatesSpec.scala
@@ -10,7 +10,6 @@ import gsp.math.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class CoordinatesSpec extends CatsSuite {
   import ArbCoordinates._
   import ArbRightAscension._
@@ -19,7 +18,9 @@ final class CoordinatesSpec extends CatsSuite {
 
   // Laws
   checkAll("Coordinates", OrderTests[Coordinates].order)
-  checkAll("Coordinates.fromHmsDms", FormatTests(Coordinates.fromHmsDms).formatWith(ArbCoordinates.strings))
+  checkAll("Coordinates.fromHmsDms",
+           FormatTests(Coordinates.fromHmsDms).formatWith(ArbCoordinates.strings)
+  )
   checkAll("Coordinates.rightAscension", LensTests(Coordinates.rightAscension))
   checkAll("Coordinates.declination", LensTests(Coordinates.declination))
 
@@ -45,21 +46,21 @@ final class CoordinatesSpec extends CatsSuite {
     forAll { (a: Coordinates, dRA: HourAngle, dDec: Angle) =>
       a.offsetWithCarry(dRA, dDec) match {
         case (cs, false) => cs.offset(-dRA, -dDec) shouldEqual a
-        case (cs, true)  => cs.offset(-dRA,  dDec) shouldEqual a
+        case (cs, true)  => cs.offset(-dRA, dDec) shouldEqual a
       }
     }
   }
 
   test("diff must be consistent with offset") {
     forAll { (a: Coordinates, b: Coordinates) =>
-      val (dRA, dDec) = a diff b
+      val (dRA, dDec) = a.diff(b)
       a.offset(dRA, dDec) shouldEqual b
     }
   }
 
   test("diff must be consistent with offsetWithCarry, and never carry") {
     forAll { (a: Coordinates, b: Coordinates) =>
-      val (dRA, dDec) = a diff b
+      val (dRA, dDec) = a.diff(b)
       a.offsetWithCarry(dRA, dDec).shouldEqual((b, false))
     }
   }
@@ -91,7 +92,9 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-  test("angularDistance must be 90° between either pole and any point on the equator, regardless of RA, within 1µas") {
+  test(
+    "angularDistance must be 90° between either pole and any point on the equator, regardless of RA, within 1µas"
+  ) {
     forAll { (ra1: RA, ra2: RA, b: Boolean) =>
       val pole  = Coordinates(ra1, if (b) Dec.Min else Dec.Max)
       val point = Coordinates(ra2, Dec.Zero)
@@ -100,7 +103,9 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-  test("angularDistance must equal any offset in declination from either pole, regardless of RA, to within 1µas") {
+  test(
+    "angularDistance must equal any offset in declination from either pole, regardless of RA, to within 1µas"
+  ) {
     forAll { (ra1: RA, ra2: RA, dec: Dec, b: Boolean) =>
       val pole = Coordinates(ra1, if (b) Dec.Min else Dec.Max)
       val Δdec = dec.toAngle + Angle.Angle90 // [0, 180]
@@ -109,7 +114,9 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-  test("angularDistance must equal any offset in right ascension along the equator, to within 1µas") {
+  test(
+    "angularDistance must equal any offset in right ascension along the equator, to within 1µas"
+  ) {
     forAll { (ra: RA, ha: HourAngle) =>
       val a = Coordinates(ra, Dec.Zero)
       val b = a.offset(ha, Angle.Angle0)
@@ -119,14 +126,18 @@ final class CoordinatesSpec extends CatsSuite {
     }
   }
 
-  test("interpolate should result in angular distance of 0° from `a` for factor 0.0, within 1µsec (15µas)") {
+  test(
+    "interpolate should result in angular distance of 0° from `a` for factor 0.0, within 1µsec (15µas)"
+  ) {
     forAll { (a: Coordinates, b: Coordinates) =>
       val Δ = a.angularDistance(a.interpolate(b, 0.0))
       Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L
     }
   }
 
-  test("interpolate should result in angular distance of 0° from `b` for factor 1.0, within 1µsec (15µas)") {
+  test(
+    "interpolate should result in angular distance of 0° from `b` for factor 1.0, within 1µsec (15µas)"
+  ) {
     forAll { (a: Coordinates, b: Coordinates) =>
       val Δ = b.angularDistance(a.interpolate(b, 1.0))
       Angle.signedMicroarcseconds.get(Δ).abs should be <= 15L

--- a/modules/tests/shared/src/test/scala/gsp/math/DeclinationSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/DeclinationSpec.scala
@@ -10,7 +10,6 @@ import gsp.math.arb._
 import gsp.math.laws.discipline._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class DeclinationSpec extends CatsSuite {
   import ArbDeclination._
   import ArbAngle._
@@ -18,7 +17,9 @@ final class DeclinationSpec extends CatsSuite {
   // Laws
   checkAll("Declination", OrderTests[Declination].order)
   checkAll("fromAngle", PrismTests(Declination.fromAngle))
-  checkAll("fromStringHMS", FormatTests(Declination.fromStringSignedDMS).formatWith(ArbAngle.stringsDMS))
+  checkAll("fromStringHMS",
+           FormatTests(Declination.fromStringSignedDMS).formatWith(ArbAngle.stringsDMS)
+  )
 
   test("Equality must be natural") {
     forAll { (a: Declination, b: Declination) =>
@@ -29,7 +30,7 @@ final class DeclinationSpec extends CatsSuite {
   test("Eq must be consistent with .toAngle.toMicroarcseconds") {
     forAll { (a: Declination, b: Declination) =>
       Eq[Long].eqv(a.toAngle.toMicroarcseconds, b.toAngle.toMicroarcseconds) shouldEqual
-      Eq[Declination].eqv(a, b)
+        Eq[Declination].eqv(a, b)
     }
   }
 
@@ -43,7 +44,7 @@ final class DeclinationSpec extends CatsSuite {
     forAll { (a: Angle) =>
       (Declination.fromAngle.getOption(a), Declination.fromAngleWithCarry(a)) match {
         case (Some(d), (dʹ, false)) => d shouldEqual dʹ
-        case (None,    (d,  true))  => d.toAngle shouldEqual a.mirrorBy(Angle.Angle90)
+        case (None, (d, true))      => d.toAngle shouldEqual a.mirrorBy(Angle.Angle90)
         case _                      => fail("Unpossible")
       }
     }

--- a/modules/tests/shared/src/test/scala/gsp/math/EpochSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/EpochSpec.scala
@@ -10,7 +10,6 @@ import gsp.math.arb._
 import gsp.math.laws.discipline._
 import java.time.LocalDateTime
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class EpochSpec extends CatsSuite {
   import ArbEpoch._
   import ArbTime._

--- a/modules/tests/shared/src/test/scala/gsp/math/HourAngleSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/HourAngleSpec.scala
@@ -10,7 +10,6 @@ import gsp.math.arb._
 import gsp.math.laws.discipline._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class HourAngleSpec extends CatsSuite {
   import ArbAngle._
 
@@ -38,7 +37,7 @@ final class HourAngleSpec extends CatsSuite {
   test("Equality must be consistent with .toMicroseconds") {
     forAll { (a: HourAngle, b: HourAngle) =>
       Eq[Long].eqv(a.toMicroseconds, b.toMicroseconds) shouldEqual
-      Eq[HourAngle].eqv(a, b)
+        Eq[HourAngle].eqv(a, b)
     }
   }
 
@@ -69,10 +68,10 @@ final class HourAngleSpec extends CatsSuite {
 
   test("Construction must normalize [non-pathological] angles") {
     forAll { (a: HourAngle, n: Int) =>
-      val factor   = n % 10
+      val factor = n % 10
       val msIn24 = 24L * 60L * 60L * 1000L * 1000L
-      val offset   = msIn24 * factor
-      val b = HourAngle.fromMicroseconds(a.toMicroseconds + offset)
+      val offset = msIn24 * factor
+      val b      = HourAngle.fromMicroseconds(a.toMicroseconds + offset)
       a shouldEqual b
     }
   }

--- a/modules/tests/shared/src/test/scala/gsp/math/JulianDateSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/JulianDateSpec.scala
@@ -14,7 +14,6 @@ import java.time.LocalDateTime
 import java.time.Instant
 import org.scalacheck.Arbitrary
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class JulianDateSpec extends CatsSuite {
 
   import ArbJulianDate._

--- a/modules/tests/shared/src/test/scala/gsp/math/JulianDateSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/JulianDateSpec.scala
@@ -8,9 +8,11 @@ import cats.kernel.laws.discipline._
 import cats.tests.CatsSuite
 
 import gsp.math.arb._
+import org.scalacheck.Gen._
 
 import java.time.LocalDateTime
-
+import java.time.Instant
+import org.scalacheck.Arbitrary
 
 @SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class JulianDateSpec extends CatsSuite {
@@ -41,12 +43,12 @@ final class JulianDateSpec extends CatsSuite {
     val y = dt.getYear + 4800.0 - a
     val m = dt.getMonthValue + 12 * a - 3.0
     dt.getDayOfMonth +
-    floor((153.0 * m + 2.0) / 5.0) +
-    365 * y +
-    floor(y / 4.0) -
-    floor(y / 100.0) +
-    floor(y / 400.0) -
-    32045.0
+      floor((153.0 * m + 2.0) / 5.0) +
+      365 * y +
+      floor(y / 4.0) -
+      floor(y / 100.0) +
+      floor(y / 400.0) -
+      32045.0
   }
 
   test("JulianDate.dayNumber matches old calculation") {
@@ -62,21 +64,45 @@ final class JulianDateSpec extends CatsSuite {
 
     // See http://aa.usno.navy.mil/data/docs/JulianDate.php
     val tests = List(
-      (LocalDateTime.of(1918, 11, 11, 11,  0,  0), 2421908.958333),
-      (LocalDateTime.of(1969,  7, 21,  2, 56, 15), 2440423.622396),
-      (LocalDateTime.of(2001,  9, 11,  8, 46,  0), 2452163.865278),
-      (LocalDateTime.of(2345,  6,  7, 12,  0,  0), 2577711.000000)
+      (LocalDateTime.of(1918, 11, 11, 11, 0, 0), 2421908.958333),
+      (LocalDateTime.of(1969, 7, 21, 2, 56, 15), 2440423.622396),
+      (LocalDateTime.of(2001, 9, 11, 8, 46, 0), 2452163.865278),
+      (LocalDateTime.of(2345, 6, 7, 12, 0, 0), 2577711.000000)
     )
 
-    tests.foreach { case (ldt, expected) =>
-      val jd  = JulianDate.ofLocalDateTime(ldt)
-      assert((expected - jd.toDouble).abs <= 0.000001)
+    tests.foreach {
+      case (ldt, expected) =>
+        val jd = JulianDate.ofLocalDateTime(ldt)
+        assert((expected - jd.toDouble).abs <= 0.000001)
     }
   }
 
   test("Modified JulianDate should almost equal JulianDate - 2400000.5") {
     forAll { (j: JulianDate) =>
       assert(j.toModifiedDouble === (j.toDouble - 2400000.5) +- 0.000000001)
+    }
+  }
+
+  test("JulianDate.ofInstant(instant).toInstant === instant") {
+    implicit val InstantEq: Eq[Instant] = Eq.fromUniversalEquals
+
+    val positiveJDInstant =
+      implicitly[Arbitrary[Instant]].arbitrary.suchThat(i => !(i.isBefore(JulianDate.Epoch)))
+
+    forAll(positiveJDInstant) { (i: Instant) =>
+      assert(JulianDate.ofInstant(i).toInstant === i)
+    }
+  }
+
+  test("JulianDate.ofInstant(julianDate.toInstant) === julianDate") {
+    forAll { (j: JulianDate) =>
+      assert(JulianDate.ofInstant(j.toInstant) === j)
+    }
+  }
+
+  test("JulianDate.fromDoubleApprox(double).toDouble =~= double") {
+    forAll(posNum[Double]) { (d: Double) =>
+      assert(JulianDate.fromDoubleApprox(d).toDouble === d +- 0.000000000001)
     }
   }
 }

--- a/modules/tests/shared/src/test/scala/gsp/math/MagnitudeValueSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/MagnitudeValueSpec.scala
@@ -4,11 +4,10 @@
 package gsp.math
 
 import cats.tests.CatsSuite
-import cats.{ Eq, Show, Order }
+import cats.{ Eq, Order, Show }
 import cats.kernel.laws.discipline._
 import gsp.math.arb._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString"))
 final class MagnitudeValueSpec extends CatsSuite {
   import ArbMagnitudeValue._
 
@@ -24,7 +23,7 @@ final class MagnitudeValueSpec extends CatsSuite {
   test("Order must be consistent with .scaledValue") {
     forAll { (a: MagnitudeValue, b: MagnitudeValue) =>
       Order[Int].comparison(a.scaledValue, b.scaledValue) shouldEqual
-      Order[MagnitudeValue].comparison(a, b)
+        Order[MagnitudeValue].comparison(a, b)
     }
   }
 

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetPSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetPSpec.scala
@@ -10,16 +10,19 @@ import gsp.math.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetPSpec extends CatsSuite {
   import ArbAngle._
   import ArbOffset._
 
   // Laws
-  checkAll("Offset.Component[Axis.P].commutativeGroup", CommutativeGroupTests[Offset.Component[Axis.P]].commutativeGroup)
+  checkAll("Offset.Component[Axis.P].commutativeGroup",
+           CommutativeGroupTests[Offset.Component[Axis.P]].commutativeGroup
+  )
   checkAll("Offset.Component[Axis.P].order", OrderTests[Offset.Component[Axis.P]].order)
   checkAll("Offset.Component.angle[Axis.P]", IsoTests(Offset.Component.angle[Axis.P]))
-  checkAll("Offset.Component.signedArcseconds[Axis.P]", SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.P]).splitMono)
+  checkAll("Offset.Component.signedArcseconds[Axis.P]",
+           SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.P]).splitMono
+  )
 
   test("Equality must be natural") {
     forAll { (a: Offset.Component[Axis.P], b: Offset.Component[Axis.P]) =>

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetQSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetQSpec.scala
@@ -10,16 +10,19 @@ import gsp.math.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetQSpec extends CatsSuite {
   import ArbAngle._
   import ArbOffset._
 
   // Laws
-  checkAll("Offset.Component[Axis.Q].commutativeGroup", CommutativeGroupTests[Offset.Component[Axis.Q]].commutativeGroup)
+  checkAll("Offset.Component[Axis.Q].commutativeGroup",
+           CommutativeGroupTests[Offset.Component[Axis.Q]].commutativeGroup
+  )
   checkAll("Offset.Component[Axis.Q].order", OrderTests[Offset.Component[Axis.Q]].order)
   checkAll("Offset.Component.angle[Axis.Q]", IsoTests(Offset.Component.angle[Axis.Q]))
-  checkAll("Offset.Component.signedArcseconds[Axis.Q]", SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.Q]).splitMono)
+  checkAll("Offset.Component.signedArcseconds[Axis.Q]",
+           SplitMonoTests(Offset.Component.signedDecimalArcseconds[Axis.Q]).splitMono
+  )
 
   test("Equality must be natural") {
     forAll { (a: Offset.Component[Axis.Q], b: Offset.Component[Axis.Q]) =>
@@ -44,6 +47,5 @@ final class OffsetQSpec extends CatsSuite {
       Offset.Component[Axis.Q](p.toAngle) shouldEqual p
     }
   }
-
 
 }

--- a/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/OffsetSpec.scala
@@ -4,14 +4,13 @@
 package gsp.math
 
 import cats.tests.CatsSuite
-import cats.{Eq, Show}
+import cats.{ Eq, Show }
 import cats.kernel.laws.discipline._
 import gsp.math.arb._
 import gsp.math.laws.discipline.SplitMonoTests
 import gsp.math.syntax.int._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class OffsetSpec extends CatsSuite {
   import ArbAngle._
   import ArbOffset._
@@ -61,40 +60,48 @@ final class OffsetSpec extends CatsSuite {
 
   test("Fixed Rotation tests") {
     val pqa = List(
-      (-1.arcsec.p,  0.arcsec.q,  90.deg) -> (( 0.arcsec.p,  1.arcsec.q)),
-      ( 0.arcsec.p,  1.arcsec.q,  90.deg) -> (( 1.arcsec.p,  0.arcsec.q)),
-      ( 1.arcsec.p,  0.arcsec.q,  90.deg) -> (( 0.arcsec.p, -1.arcsec.q)),
-      ( 0.arcsec.p, -1.arcsec.q,  90.deg) -> ((-1.arcsec.p,  0.arcsec.q)),
-      (-1.arcsec.p,  0.arcsec.q, -90.deg) -> (( 0.arcsec.p, -1.arcsec.q)),
-      ( 0.arcsec.p,  1.arcsec.q, -90.deg) -> ((-1.arcsec.p,  0.arcsec.q)),
-      ( 1.arcsec.p,  0.arcsec.q, -90.deg) -> (( 0.arcsec.p,  1.arcsec.q)),
-      ( 0.arcsec.p, -1.arcsec.q, -90.deg) -> (( 1.arcsec.p,  0.arcsec.q)),
-      (-1.arcsec.p,  0.arcsec.q,  30.deg) -> ((-866025.µas.p,  500000.µas.q)),
-      (-1.arcsec.p,  0.arcsec.q, -30.deg) -> ((-866025.µas.p, -500000.µas.q)),
-      (-2999291.µas.p,  9537000.µas.q,  Angle.fromDMS(148, 0, 54, 775, 807)) -> (( 7595657.µas.p, -6500470.µas.q)),
-      ( 7595657.µas.p, -6500470.µas.q, -Angle.fromDMS(148, 0, 54, 775, 807)) -> ((-2999291.µas.p,  9537000.µas.q))
+      (-1.arcsec.p, 0.arcsec.q, 90.deg)                                     -> ((0.arcsec.p, 1.arcsec.q)),
+      (0.arcsec.p, 1.arcsec.q, 90.deg)                                      -> ((1.arcsec.p, 0.arcsec.q)),
+      (1.arcsec.p, 0.arcsec.q, 90.deg)                                      -> ((0.arcsec.p, -1.arcsec.q)),
+      (0.arcsec.p, -1.arcsec.q, 90.deg)                                     -> ((-1.arcsec.p, 0.arcsec.q)),
+      (-1.arcsec.p, 0.arcsec.q, -90.deg)                                    -> ((0.arcsec.p, -1.arcsec.q)),
+      (0.arcsec.p, 1.arcsec.q, -90.deg)                                     -> ((-1.arcsec.p, 0.arcsec.q)),
+      (1.arcsec.p, 0.arcsec.q, -90.deg)                                     -> ((0.arcsec.p, 1.arcsec.q)),
+      (0.arcsec.p, -1.arcsec.q, -90.deg)                                    -> ((1.arcsec.p, 0.arcsec.q)),
+      (-1.arcsec.p, 0.arcsec.q, 30.deg)                                     -> ((-866025.µas.p, 500000.µas.q)),
+      (-1.arcsec.p, 0.arcsec.q, -30.deg)                                    -> ((-866025.µas.p, -500000.µas.q)),
+      (-2999291.µas.p, 9537000.µas.q, Angle.fromDMS(148, 0, 54, 775, 807))  -> ((7595657.µas.p,
+                                                                                -6500470.µas.q
+                                                                               )
+      ),
+      (7595657.µas.p, -6500470.µas.q, -Angle.fromDMS(148, 0, 54, 775, 807)) -> ((-2999291.µas.p,
+                                                                                 9537000.µas.q
+                                                                                )
+      )
     )
 
-    pqa.foreach { case ((p, q, θ), (pʹ, qʹ)) =>
-      val expected = Offset(pʹ, qʹ)
-      val actual = Offset(p, q).rotate(θ)
-      if (Eq[Offset].neqv(expected, actual)) {
-        val t = s"Offset(${Offset.P.signedDecimalArcseconds.get(p)}, ${Offset.Q.signedDecimalArcseconds.get(q)}).rotate(${θ.toSignedDoubleDegrees}º)"
+    pqa.foreach {
+      case ((p, q, θ), (pʹ, qʹ)) =>
+        val expected = Offset(pʹ, qʹ)
+        val actual   = Offset(p, q).rotate(θ)
+        if (Eq[Offset].neqv(expected, actual)) {
+          val t =
+            s"Offset(${Offset.P.signedDecimalArcseconds.get(p)}, ${Offset.Q.signedDecimalArcseconds
+              .get(q)}).rotate(${θ.toSignedDoubleDegrees}º)"
 
-        fail(
-          s"""$t
+          fail(s"""$t
              |  Expected: $expected
              |  Actual..: $actual
         """.stripMargin)
-      }
+        }
     }
   }
 
   test("Rotation is invertable within 1 µas") {
     // not exactly invertable because of rounding
     forAll { (o: Offset, θ: Angle) =>
-      val oʹ = o.rotate(θ).rotate(-θ)
-      val (p,  q)  = Offset.signedMicroarcseconds.get(o)
+      val oʹ       = o.rotate(θ).rotate(-θ)
+      val (p, q)   = Offset.signedMicroarcseconds.get(o)
       val (pʹ, qʹ) = Offset.signedMicroarcseconds.get(oʹ)
       assert(
         ((p - pʹ).abs <= 1) && ((q - qʹ).abs <= 1)

--- a/modules/tests/shared/src/test/scala/gsp/math/PlaceSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/PlaceSpec.scala
@@ -8,7 +8,6 @@ import cats.{ Eq, Show }
 import gsp.math.arb._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 object PlaceSpec extends CatsSuite {
   import ArbPlace._
   import ArbDeclination._

--- a/modules/tests/shared/src/test/scala/gsp/math/ProperMotionSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/ProperMotionSpec.scala
@@ -8,7 +8,6 @@ import cats.kernel.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class ProperMotionSpec extends CatsSuite {
   import ArbAngle._
   import ArbCoordinates._

--- a/modules/tests/shared/src/test/scala/gsp/math/RightAscensionSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/RightAscensionSpec.scala
@@ -4,13 +4,12 @@
 package gsp.math
 
 import cats.tests.CatsSuite
-import cats.{ Eq, Show, Order }
+import cats.{ Eq, Order, Show }
 import cats.kernel.laws.discipline._
 import gsp.math.arb._
 import gsp.math.laws.discipline._
 import monocle.law.discipline._
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class RightAscensionSpec extends CatsSuite {
   import ArbRightAscension._
   import ArbAngle._
@@ -19,7 +18,9 @@ final class RightAscensionSpec extends CatsSuite {
   checkAll("RightAscension", OrderTests[RightAscension].order)
   checkAll("fromAngleExact", PrismTests(RightAscension.fromAngleExact))
   checkAll("fromHourAngle", IsoTests(RightAscension.fromHourAngle))
-  checkAll("fromStringHMS", FormatTests(RightAscension.fromStringHMS).formatWith(ArbAngle.stringsHMS))
+  checkAll("fromStringHMS",
+           FormatTests(RightAscension.fromStringHMS).formatWith(ArbAngle.stringsHMS)
+  )
 
   test("Equality must be natural") {
     forAll { (a: RightAscension, b: RightAscension) =>
@@ -29,8 +30,10 @@ final class RightAscensionSpec extends CatsSuite {
 
   test("Order must be consistent with .toHourAngle.toMicroarcseconds") {
     forAll { (a: RightAscension, b: RightAscension) =>
-      Order[Long].comparison(a.toHourAngle.toMicroarcseconds, b.toHourAngle.toMicroarcseconds) shouldEqual
-      Order[RightAscension].comparison(a, b)
+      Order[Long].comparison(a.toHourAngle.toMicroarcseconds,
+                             b.toHourAngle.toMicroarcseconds
+      ) shouldEqual
+        Order[RightAscension].comparison(a, b)
     }
   }
 

--- a/modules/tests/shared/src/test/scala/gsp/math/WavelengthSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/WavelengthSpec.scala
@@ -4,20 +4,19 @@
 package gsp.math
 
 import cats.tests.CatsSuite
-import cats.{ Eq, Show, Order }
+import cats.{ Eq, Order, Show }
 import cats.kernel.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 final class WavelengthSpec extends CatsSuite {
   import ArbWavelength._
 
   // Laws
-  checkAll("Wavelength",      OrderTests[Wavelength].order)
-  checkAll("fromPicometers",  PrismTests(Wavelength.fromPicometers))
+  checkAll("Wavelength", OrderTests[Wavelength].order)
+  checkAll("fromPicometers", PrismTests(Wavelength.fromPicometers))
 
   // These are not valid `Format` because they don't round trip Wavelength -> Int -> Wavelength
   // Switching to bigger units loses precision.
@@ -34,7 +33,7 @@ final class WavelengthSpec extends CatsSuite {
   test("Order must be consistent with .toPicometers") {
     forAll { (a: Wavelength, b: Wavelength) =>
       Order[Int].comparison(a.toPicometers, b.toPicometers) shouldEqual
-      Order[Wavelength].comparison(a, b)
+        Order[Wavelength].comparison(a, b)
     }
   }
 

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/ImprovedSkyCalcSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/ImprovedSkyCalcSpec.scala
@@ -10,9 +10,7 @@ import cats.Monoid
 import cats.Show
 import java.time._
 import gsp.math.Coordinates
-import gsp.math.Angle
 import gsp.math.Place
-import gsp.math.Lat
 
 // This is just a basic case, mostly to test linking in JS.
 // Property based testing is in ImprovedSkyCalcSpecJVM, where output
@@ -30,18 +28,6 @@ object ImprovedSkyCalcSpec extends SimpleIOSuite {
       (i.getNano / NanosPerMillis * NanosPerMillis).toLong
     )
 
-  private val GN     =
-    Place(
-      Lat.fromAngleWithCarry(Angle.fromDoubleDegrees(19.8238068))._1,
-      Angle.fromDoubleDegrees(-155.4690550),
-      4213.0
-    )
-  private val GS     =
-    Place(
-      Lat.fromAngleWithCarry(Angle.fromDoubleDegrees(-30.2407494))._1,
-      Angle.fromDoubleDegrees(-70.7366867),
-      2722.0
-    )
   private val M51    = Coordinates.fromHmsDms.getOption("13 29 52.698000 +47 11 42.929988").get
   private val Moment = truncateInstantToMillis(
     ZonedDateTime.of(LocalDate.of(2000, 1, 1), LocalTime.MIDNIGHT, ZoneOffset.UTC).toInstant
@@ -57,8 +43,8 @@ object ImprovedSkyCalcSpec extends SimpleIOSuite {
   pureTest("ImprovedSkyCalcSpec: Elevation of M51 at midnight 2000-01-01 UTC") {
     Monoid[Expectations].combineAll(
       expected.map {
-        case ((location, coords, instant), elevation) =>
-          val calc    = ImprovedSkyCalc(location)
+        case ((place, coords, instant), elevation) =>
+          val calc    = ImprovedSkyCalc(place)
           val results = calc.calculate(coords, instant, false)
           expect(results.altitudeRaw === elevation)
       }

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import cats.tests.CatsSuite
+import cats.{ Eq, Show }
+import gsp.math.arb._
+import gsp.math.skycalc.TwilightBoundType
+
+@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
+object TwilightBoundTypeSpec extends CatsSuite {
+  import ArbTwilightBoundType._
+
+  test("Equality must be natural") {
+    forAll { (a: TwilightBoundType, b: TwilightBoundType) =>
+      a.equals(b) shouldEqual Eq[TwilightBoundType].eqv(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: TwilightBoundType) =>
+      a.toString shouldEqual Show[TwilightBoundType].show(a)
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
@@ -8,7 +8,6 @@ import cats.{ Eq, Show }
 import gsp.math.arb._
 import gsp.math.skycalc.TwilightBoundType
 
-@SuppressWarnings(Array("org.wartremover.warts.ToString", "org.wartremover.warts.Equals"))
 object TwilightBoundTypeSpec extends CatsSuite {
   import ArbTwilightBoundType._
 

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightCalcSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightCalcSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math.skycalc
+
+import weaver._
+import cats._
+import gsp.math.Place
+import java.time.LocalDate
+import org.scalactic.Tolerance
+
+object TwilightCalcSpec extends SimpleIOSuite with Tolerance {
+  import TwilightBoundType._
+
+  private val Date = LocalDate.of(2000, 1, 1)
+
+  // Known results with OCS
+  private val expected: Map[(Place, TwilightBoundType, LocalDate), (Long, Long)] =
+    Map(
+      (GN, Official, Date)     -> ((946785833352L, 946831636357L)),
+      (GN, Civil, Date)        -> ((946786687500L, 946830782669L)),
+      (GN, Nautical, Date)     -> ((946788331171L, 946829139780L)),
+      (GN, Astronomical, Date) -> ((946789955319L, 946827516290L)),
+      (GS, Official, Date)     -> ((946771013083L, 946805782320L)),
+      (GS, Civil, Date)        -> ((946772131479L, 946804663970L)),
+      (GS, Nautical, Date)     -> ((946774129507L, 946802666017L)),
+      (GS, Astronomical, Date) -> ((946776266779L, 946800528816L))
+    )
+
+  pureTest("TwilightCalcSpec: Sunrise and sunset on 2000-01-01") {
+    Monoid[Expectations].combineAll(
+      expected.map {
+        case ((place, tbType, date), (s, e)) =>
+          val (start, end) = TwilightCalc.calculate(tbType, date, place).get
+          // The use of a different JulianDate throughout the calculations produces a very slight difference,
+          // therefore we allow a couple of milliseconds of tolerance.
+          expect((start.toEpochMilli +- 2).isWithin(s))
+            .and(expect((end.toEpochMilli +- 2).isWithin(e)))
+      }
+    )
+  }
+
+}

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/package.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import java.time.ZoneId
+
+package object skycalc {
+  val GN =
+    Place(
+      Lat.fromAngleWithCarry(Angle.fromDoubleDegrees(19.8238068))._1,
+      Angle.fromDoubleDegrees(-155.4690550),
+      4213.0,
+      ZoneId.of("Pacific/Honolulu")
+    )
+
+  val GS =
+    Place(
+      Lat.fromAngleWithCarry(Angle.fromDoubleDegrees(-30.2407494))._1,
+      Angle.fromDoubleDegrees(-70.7366867),
+      2722.0,
+      ZoneId.of("America/Santiago")
+    )
+}


### PR DESCRIPTION
* Methods from `ImprovedSkyCalcMethods` that were used to compute twilights are now in `SunCalc` trait. These used `JulianDate`, which was substituted for the new one.
* Added methods to `JulianDate` to convert to `Instant` and to construct (approximately) from a `Double`.
* Computations previously performed in `TwilightBoundedNight` are now in `TwilightCalc`. The idea is to keep the math in `gsp-math`. `gsp-core` will contain a `TwilightBoundedNight` which is trivial to implement (already done, will send PR to `gsp-core` after we publish this).
* Twilight computations return an `Option` in case there's no sunset or sunrise for the specified parameters.
* JVM-only tests were added comparing output to OCS. JVM and JS tests were added computing some known results.
* Some formatting.