### PR TITLE
Add order to TwilightBoundType. Fix test.

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightBoundType.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/skycalc/TwilightBoundType.scala
@@ -4,6 +4,7 @@
 package gsp.math.skycalc
 
 import cats._
+import cats.implicits._
 
 /**
   * Definition for how the range from sunset to sunrise should be defined for
@@ -21,8 +22,11 @@ object TwilightBoundType {
 
   val all: List[TwilightBoundType] = List(Official, Civil, Nautical, Astronomical)
 
+  // Hashed index lookup, for efficient use as an `Order`.
+  private lazy val indexOfTag: Map[TwilightBoundType, Int] = all.zipWithIndex.toMap
+
   /** @group Typeclass Instances */
-  implicit val TwilightBoundTypeEqual: Eq[TwilightBoundType] = Eq.fromUniversalEquals
+  implicit val TwilightBoundTypeOrder: Order[TwilightBoundType] = Order.by(indexOfTag)
 
   /** @group Typeclass Instances */
   implicit val TwilightBoundTypeShow: Show[TwilightBoundType] = Show.show(_.name)

--- a/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/skycalc/TwilightBoundTypeSpec.scala
@@ -5,11 +5,18 @@ package gsp.math
 
 import cats.tests.CatsSuite
 import cats.{ Eq, Show }
+import cats.kernel.laws.discipline._
 import gsp.math.arb._
 import gsp.math.skycalc.TwilightBoundType
 
-object TwilightBoundTypeSpec extends CatsSuite {
+final class TwilightBoundTypeSpec extends CatsSuite {
   import ArbTwilightBoundType._
+
+  // Laws
+  checkAll("TwilightBoundType", EqTests[TwilightBoundType].eqv)
+  checkAll("TwilightBoundType",
+           OrderTests[TwilightBoundType](TwilightBoundType.TwilightBoundTypeOrder).order
+  )
 
   test("Equality must be natural") {
     forAll { (a: TwilightBoundType, b: TwilightBoundType) =>


### PR DESCRIPTION
* Define an `Order[TwilightBoundType]` so we can define it for `TwilightBoundedNight` in `gsp-core`.
* `TwilightBoundTypeSpec` was not running.