### PR TITLE
Utility methods to convert double values to ra/dec

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/Angle.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Angle.scala
@@ -498,8 +498,8 @@ object HourAngle extends HourAngleOptics {
    * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
    * @group Constructors
    */
-  def fromDoubleDegrees(hs: Double): HourAngle =
-    Angle.hourAngle.get(Angle.fromDoubleDegrees(hs))
+  def fromDoubleDegrees(deg: Double): HourAngle =
+    Angle.hourAngle.get(Angle.fromDoubleDegrees(deg))
 
   /**
    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,

--- a/modules/math/shared/src/main/scala/gsp/math/Angle.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Angle.scala
@@ -257,6 +257,7 @@ object Angle extends AngleOptics {
     def format: String = f"$degrees%02d:$arcminutes%02d:$arcseconds%02d.$milliarcseconds%03d$microarcseconds%03d"
     override def toString: String = s"DMS($format)"
   }
+
   object DMS {
     implicit val eqDMS: Eq[DMS] =
       Eq.by(_.toAngle)
@@ -487,11 +488,18 @@ object HourAngle extends HourAngleOptics {
   }
 
   /**
-   * Construct a new Angle of the given magnitude in floating point hours, modulo 24h. Approximate.
+   * Construct a new HourAngle of the given magnitude in floating point hours, modulo 24h. Approximate.
    * @group Constructors
    */
   def fromDoubleHours(hs: Double): HourAngle =
     fromMicroseconds((hs * µsPerHour).round)
+
+  /**
+   * Construct a new HourAngle of the given magnitude in double degrees, modulo 360°. Approximate.
+   * @group Constructors
+   */
+  def fromDoubleDegrees(hs: Double): HourAngle =
+    Angle.hourAngle.get(Angle.fromDoubleDegrees(hs))
 
   /**
    * Construct a new HourAngle of the given magnitude as a sum of hours, minutes, seconds,
@@ -545,6 +553,7 @@ object HourAngle extends HourAngleOptics {
     def format: String = f"$hours%02d:$minutes%02d:$seconds%02d.$milliseconds%03d$microseconds%03d"
     override def toString: String = format
   }
+
   object HMS {
     implicit val eqHMS: Eq[HMS] =
       Eq.by(_.toHourAngle)

--- a/modules/math/shared/src/main/scala/gsp/math/Declination.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Declination.scala
@@ -63,6 +63,14 @@ object Declination extends DeclinationOptics {
       (fromAngle.unsafeGet(a mirrorBy Angle.Angle90), true)
     }
 
+  /**
+   * Attempt to build a `Declination` from double degrees. To get a `Declination` degrees must be
+   * in the range [-90°, 90°], or [270 - 360) + [0-90]
+   * @group Constructors
+   */
+  def fromDoubleDegrees(deg: Double): Option[Declination] = 
+    fromAngle.getOption(Angle.fromDoubleDegrees(deg))
+
   def fromRadians(rad: Double): Option[Declination] =
     fromAngle.getOption(Angle.fromDoubleRadians(rad))
 

--- a/modules/math/shared/src/main/scala/gsp/math/RightAscension.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/RightAscension.scala
@@ -54,6 +54,13 @@ object RightAscension extends RightAscensionOptics {
     RightAscension(Angle.hourAngle.get(Angle.fromDoubleRadians(rad)))
 
   /**
+   * Construct a `RightAscension` from an angle in degrees. Approximate
+   * @group Constructors
+   */
+  def fromDoubleDegrees(deg: Double): RightAscension =
+    fromHourAngle.get(HourAngle.fromDoubleDegrees(deg))
+
+  /**
    * The `RightAscension` at zero degrees.
    * @group Constructors
    */

--- a/modules/tests/shared/src/test/scala/gsp/math/DeclinationSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/DeclinationSpec.scala
@@ -65,4 +65,13 @@ final class DeclinationSpec extends CatsSuite {
     }
   }
 
+  test("Declination from degrees") {
+    // Sanity checks
+    Declination.fromDoubleDegrees(0) shouldEqual Declination.Zero.some
+    Declination.fromDoubleDegrees(90) shouldEqual Declination.Max.some
+    Declination.fromDoubleDegrees(-90) shouldEqual Declination.Min.some
+    Declination.fromDoubleDegrees(-90) shouldEqual Declination.fromDoubleDegrees(270)
+    Declination.fromDoubleDegrees(180) shouldEqual None
+  }
+
 }


### PR DESCRIPTION
In aladin we get coordinates in doubles, These methods will make it easier to handle these cases