### PR TITLE
Make toMicrosexigesimal public

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/Angle.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Angle.scala
@@ -233,7 +233,7 @@ object Angle extends AngleOptics {
     Order.by(signedMicroarcseconds.get)
 
   // This works for both DMS and HMS so let's just do it once.
-  protected[math] def toMicrosexigesimal(micros: Long): (Int, Int, Int, Int, Int) = {
+  def toMicrosexigesimal(micros: Long): (Int, Int, Int, Int, Int) = {
     val µs =  micros                               % 1000L
     val ms = (micros /  1000L)                     % 1000L
     val s  = (micros / (1000L * 1000L))            % 60L


### PR DESCRIPTION
I'd like to use this method in explore. I'm not sure why is it protected