### PR TITLE
Use refined and coulomb to define Wavelength

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,10 @@ lazy val geminiLocalesVersion        = "0.5.0"
 lazy val jtsVersion                  = "0.0.9"
 lazy val svgdotjsVersion             = "0.0.1"
 lazy val newType                     = "0.4.4"
+lazy val coulombVersion              = "0.5.0"
+lazy val spireVersion                = "0.17.0-RC1"
+lazy val singletonOpsVersion         = "0.5.1"
+lazy val refinedVersion              = "0.9.15"
 
 inThisBuild(
   Seq(
@@ -33,7 +37,15 @@ lazy val math = crossProject(JVMPlatform, JSPlatform)
       "com.github.julien-truffaut" %%% "monocle-core"            % monocleVersion,
       "com.github.julien-truffaut" %%% "monocle-macro"           % monocleVersion,
       "org.scala-lang.modules"     %%% "scala-collection-compat" % collCompatVersion,
-      "edu.gemini"                 %%% "gpp-jts"                 % jtsVersion
+      "edu.gemini"                 %%% "gpp-jts"                 % jtsVersion,
+      "com.manyangled"             %%% "coulomb"                 % coulombVersion,
+      "com.manyangled"             %%% "coulomb-si-units"        % coulombVersion,
+      "com.manyangled"             %%% "coulomb-cats"            % coulombVersion,
+      "com.manyangled"             %%% "coulomb-refined"         % coulombVersion,
+      "org.typelevel"              %%% "spire"                   % spireVersion,
+      "eu.timepit"                 %%% "singleton-ops"           % singletonOpsVersion,
+      "eu.timepit"                 %%% "refined"                 % refinedVersion,
+      "eu.timepit"                 %%% "refined-cats"            % refinedVersion
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))
@@ -60,7 +72,9 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel"              %%% "cats-testkit"           % catsVersion,
       "org.typelevel"              %%% "cats-testkit-scalatest" % catsTestkitScalaTestVersion,
-      "com.github.julien-truffaut" %%% "monocle-law"            % monocleVersion
+      "com.github.julien-truffaut" %%% "monocle-law"            % monocleVersion,
+      "org.typelevel"              %%% "spire-laws"             % spireVersion,
+      "eu.timepit"                 %%% "refined-scalacheck"     % refinedVersion
     )
   )
   .jvmConfigure(_.enablePlugins(AutomateHeaderPlugin))

--- a/modules/math/shared/src/main/scala/gsp/math/Wavelength.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Wavelength.scala
@@ -3,25 +3,60 @@
 
 package gsp.math
 
-import cats.{ Order, Show }
-import cats.instances.int._
-import gsp.math.syntax.prism._
+import cats.Order
+import cats.Show
+import cats.implicits._
+import coulomb._
+import eu.timepit.refined._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.numeric._
+import gsp.math.units._
+import monocle.Iso
 import monocle.Prism
+import spire.math.Rational
 
 /**
- * Exact wavelengths represented as unsigned integral picometers in the range [0 .. Int.MaxValue]
- * which means the largest representable wavelength is 2.147483647 mm.
- * @param toPicometers This wavelength in integral picometers (10^-12^ of a meter).
- */
-sealed abstract case class Wavelength private (toPicometers: Int) {
-  // Sanity check … should be correct via the companion constructor.
-  assert(toPicometers >= 0, s"Invariant violated. $toPicometers is negative.")
+  * Exact wavelengths represented as positive integral picometers in the range (0 .. PositiveInt.MaxValue]
+  * which means the largest representable wavelength is 2.147483647 mm.
+  * @param toPicometers This wavelength in positive integral picometers (10^-12^ of a meter).
+  */
+final case class Wavelength(toPicometers: Quantity[PositiveInt, Picometer]) {
+
+  /**
+    * Returns the wavelength value in nanometers
+    * The exact nanometer value needs to be represented as a Rational
+    */
+  def nm: Quantity[Rational, Nanometer] = toPicometers.to[Rational, Nanometer]
+
+  def nanometer: Quantity[Rational, Nanometer] = nm
+
+  /**
+    * Returns the wavelength value in angstrom
+    * The exact angstrom value needs to be represented as a Rational
+    */
+  def Å: Quantity[Rational, Angstrom] = toPicometers.to[Rational, Angstrom]
+
+  def angstrom: Quantity[Rational, Angstrom] = Å
+
+  override def toString: String =
+    s"Wavelength(${toPicometers.show})"
 }
 
 object Wavelength {
+  lazy val Min: Wavelength   = unsafeFromInt(1)
+  lazy val Max: Wavelength   = unsafeFromInt(Int.MaxValue)
+  // Max allowed value in nanometers
+  lazy val MaxNanometer: Int = Int.MaxValue / BigInt(10).pow(3).toInt
+  // Max allowed value in angstrom
+  val MaxAngstrom: Int       = Int.MaxValue / BigInt(10).pow(2).toInt
 
-  final lazy val Min: Wavelength = fromPicometers.unsafeGet(0)
-  final lazy val Max: Wavelength = fromPicometers.unsafeGet(Int.MaxValue)
+  /**
+    * Construct a wavelength from a positive int
+    * @group constructor
+    */
+  def apply(picometers: PositiveInt): Wavelength =
+    new Wavelength(picometers.withUnit[Picometer])
 
   /** @group Typeclass Instances */
   implicit val WavelengthShow: Show[Wavelength] =
@@ -29,72 +64,50 @@ object Wavelength {
 
   /** @group Typeclass Instances */
   implicit val WavelengthOrd: Order[Wavelength] =
-    Order.by(_.toPicometers)
+    Order.by(_.toPicometers.value)
 
   /**
-   * Prism from Int in pm into Wavelength and back.
-   * @group Optics
-   */
+    * Try to build a Wavelength from a plain Int. Negatives and Zero will produce a None
+    * @group constructor
+    */
+  def fromInt(i: Int): Option[Wavelength] =
+    refineV[Positive](i).toOption.map(apply)
+
+  def unsafeFromInt(i: Int): Wavelength =
+    fromInt(i).getOrElse(sys.error(s"Cannot build a Wavelength with value $i"))
+
+  /**
+    * Try to build a Wavelength with a value in nm in the range (0 .. 214783]
+    * @group constructor
+    */
+  def fromNanometers(nm: Int): Option[Wavelength] =
+    refineV[Positive](nm).toOption.flatMap(nm =>
+      if (nm.value <= MaxNanometer) Wavelength(nm.withUnit[Nanometer]).some else none
+    )
+
+  /**
+    * Try to build a Wavelength with a value in angstrom in the range (0 .. 2147]
+    * @group constructor
+    */
+  def fromAngstrom(a: Int): Option[Wavelength] =
+    refineV[Positive](a).toOption.flatMap(a =>
+      if (a.value <= MaxAngstrom) Some(Wavelength(a.withUnit[Angstrom])) else None
+    )
+
+  /**
+    * Iso from PositiveInt in pm into Wavelength and back.
+    * @group Optics
+    */
+  val picometers: Iso[PositiveInt, Wavelength] =
+    Iso[PositiveInt, Wavelength](i => Wavelength(i.withUnit[Picometer]))(_.toPicometers.value)
+
+  /**
+    * Prism from Int in pm into Wavelength and back.
+    * @group Optics
+    */
   val fromPicometers: Prism[Int, Wavelength] =
-    Prism((n: Int) => Some(n).filter(_ >= 0).map(new Wavelength(_) {}))(_.toPicometers)
-
-
-  // A Format such as this one which converts to Å:
-  //  fromPicometers.asFormat.imapA(_ / 100, _ * 100)
-  // is not a valid Format since λ => Int (Å) => λ loses precision
-
-  /**
-   * Poor man's uncomposable "optics" for converting between wavelength units.
-   * @param name unit name for the resulting integral value of the reverseGet
-   *             (eg, "nm" for nanometers)
-   * @param exp power of 10 difference relative to pm (Å is 2, nm is 3, μm 6)
-   */
-  sealed abstract case class UnitConverter(name: String, exp: Int) {
-    private val p: Int = BigInt(10).pow(exp).toInt
-
-    /**
-     * Max value in these units that can be stored in a Wavelength.
-     */
-    val maxValue: Int =
-      Int.MaxValue / p
-
-    /**
-     * Creates a Wavelength from an Int in the corresponding units, provided it
-     * is in the range 0 to `maxValue`.
-     * @param n value in corresponding unit
-     * @return Some(Wavelength) provided n is in range [0, `maxValue`], None
-     *         otherwise
-     */
-    def getOption(n: Int): Option[Wavelength] =
-      if ((n < 0) || (n > maxValue)) None else fromPicometers.getOption(n * p)
-
-    def unsafeGet(n: Int): Wavelength =
-      getOption(n).getOrElse(sys.error(s"$n ($name) is not in range [0, $maxValue]"))
-
-    /**
-     * Converts Wavelength to an Int in the corresponding units, losing precision.
-     */
-    def reverseGet(w: Wavelength): Int =
-      w.toPicometers / p
-
-  }
-
-  /**
-   * Returns a `UnitConverter` for angstroms in the range 0 to 21474836.
-   */
-  val fromAngstroms: UnitConverter =
-    new UnitConverter("Å", 2) {}
-
-  /**
-   * Returns a `UnitConverter` for nm in the range 0 to 214783.
-   */
-  val fromNanometers: UnitConverter =
-    new UnitConverter("nm", 3) {}
-
-  /**
-   * Returns a `UnitConverter` for μm in the range 0 to 2147.
-   */
-  val fromMicrometers: UnitConverter =
-    new UnitConverter("μm", 6) {}
+    Prism[Int, Wavelength](pm =>
+      refineV[Positive](pm).toOption.map(v => Wavelength(v.withUnit[Picometer]))
+    )(_.toPicometers.value)
 
 }

--- a/modules/math/shared/src/main/scala/gsp/math/Wavelength.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Wavelength.scala
@@ -7,6 +7,7 @@ import cats.Order
 import cats.Show
 import cats.implicits._
 import coulomb._
+import coulomb.cats.implicits._
 import eu.timepit.refined._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
@@ -49,7 +50,7 @@ object Wavelength {
   // Max allowed value in nanometers
   lazy val MaxNanometer: Int = Int.MaxValue / BigInt(10).pow(3).toInt
   // Max allowed value in angstrom
-  val MaxAngstrom: Int       = Int.MaxValue / BigInt(10).pow(2).toInt
+  lazy val MaxAngstrom: Int  = Int.MaxValue / BigInt(10).pow(2).toInt
 
   /**
     * Construct a wavelength from a positive int
@@ -64,7 +65,7 @@ object Wavelength {
 
   /** @group Typeclass Instances */
   implicit val WavelengthOrd: Order[Wavelength] =
-    Order.by(_.toPicometers.value)
+    Order.by(_.toPicometers)
 
   /**
     * Try to build a Wavelength from a plain Int. Negatives and Zero will produce a None

--- a/modules/math/shared/src/main/scala/gsp/math/units.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/units.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import coulomb.unitops.ConvertableUnits
+import coulomb.unitops.UnitConverter
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
+import spire.math.Rational
+
+trait units {
+  // Wavelength units
+  type Picometer = Pico %* Meter
+  type Nanometer = Nano %* Meter
+  type Angstrom  = Hecto %* Picometer
+
+  // Ints greater than zero
+  type PositiveInt = Int Refined Positive
+
+  // PositiveInt can be converted to Rational exactly
+  implicit def rationalConverter[U1, U2](implicit
+    cu: ConvertableUnits[U1, U2]
+  ): UnitConverter[PositiveInt, U1, Rational, U2] =
+    new UnitConverter[PositiveInt, U1, Rational, U2] {
+      @inline def vcnv(v: PositiveInt): Rational =
+        cu.coef * v.value
+    }
+
+  // This can build a converter for units that use PositiveInt but they are exact only
+  // if the coef is more than 1 and whole, i.e. going from Nanometer to Picometer
+  // The reverse is not true, remaining in the PositiveInt domain we can't ensure we can go from
+  // Picometer to Nanometer without loosing precision
+  // Thus we shouldn't make this implicit by default~
+  def unsafePositiveIntConverter[U1, U2](implicit
+    cu: ConvertableUnits[U1, U2]
+  ): UnitConverter[PositiveInt, U1, PositiveInt, U2] =
+    new UnitConverter[PositiveInt, U1, PositiveInt, U2] {
+      @inline def vcnv(v: PositiveInt): PositiveInt =
+        // We only allow the conversion if the coef is more than one and exact
+        if (cu.coef.compareToOne > 0 && cu.coef.isWhole)
+          // given the check above this should be positive and the refinement should always succeed
+          refineV[Positive]((cu.coef * v.value).toInt).getOrElse(sys.error(s"Shouldn't happen"))
+        else
+          sys.error(s"Cannot convert exactly with coef ${cu.coef}")
+
+    }
+
+  // Implicit conversions that can be exact as Pico/Nano/Angstrom are multiples of 10
+  implicit val convNP: UnitConverter[PositiveInt, Nanometer, PositiveInt, Picometer] =
+    unsafePositiveIntConverter[Nanometer, Picometer]
+
+  implicit val convAP: UnitConverter[PositiveInt, Angstrom, PositiveInt, Picometer] =
+    unsafePositiveIntConverter[Angstrom, Picometer]
+
+}
+
+object units extends units

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbWavelength.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbWavelength.scala
@@ -3,19 +3,21 @@
 
 package gsp.math.arb
 
+import eu.timepit.refined.scalacheck.numeric._
 import gsp.math.Wavelength
-import gsp.math.syntax.prism._
-import org.scalacheck._
-import org.scalacheck.Gen._
+import gsp.math.units._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen._
+import org.scalacheck._
 
 trait ArbWavelength {
 
-  implicit val arbWavelength: Arbitrary[Wavelength] =
-    Arbitrary(choose(0, Int.MaxValue).map(Wavelength.fromPicometers.unsafeGet(_)))
+  implicit val arbWavelength: Arbitrary[Wavelength] = Arbitrary {
+    arbitrary[PositiveInt].map(Wavelength(_))
+  }
 
   implicit val cogWavelength: Cogen[Wavelength] =
-    Cogen[Int].contramap(_.toPicometers)
+    Cogen[Int].contramap(_.toPicometers.value.value)
 
 }
 

--- a/modules/tests/shared/src/test/scala/gsp/math/WavelengthSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/WavelengthSpec.scala
@@ -51,7 +51,7 @@ final class WavelengthSpec extends CatsSuite {
     Wavelength.fromAngstrom(Wavelength.MaxAngstrom + 1) shouldEqual none
   }
 
-  test("toAmstrong") {
+  test("toAngstrom") {
     forAll { (a: PositiveInt) =>
       whenever(a.value <= Wavelength.MaxAngstrom) {
         Wavelength.fromAngstrom(a).map(_.angstrom.value.isWhole) shouldEqual true.some


### PR DESCRIPTION
This PR updates `Wavelength` to use `coulomb` for units and experimentally use `refined` for the values.
`Wavelength` is now defined as a quantity in picometers. It only makes sense if the value is greater than zero thus we use `refined` to define the numeric type wavelength can use.

This PR took me a while to realize some subtle details. For example to convert exactly to nm or angstrom, you need a different numeric type, in this case a `Rational`.

`UnitConversion` was removed as we can convert directly using `coulomb`

Using `refined` adds a bit of ceremony in some cases