### PR TITLE
Move classes from gsp-core to gsp-math

### DIFF
--- a/modules/math/shared/src/main/scala/gsp/math/ApparentRadialVelocity.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/ApparentRadialVelocity.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import cats._
+import coulomb._
+import coulomb.cats.implicits._
+import gsp.math.units._
+import spire.std.bigDecimal._
+
+/**
+  * Representation of a radial velocity in meters per second
+  * Unlike RadialVelocity this is not limited to the speed of light
+  * Apparent Radial Velocity is often represented as cz
+  */
+final case class ApparentRadialVelocity(cz: Quantity[BigDecimal, MetersPerSecond]) {
+
+  /**
+    * Converts the apparent radial velocity to a Redshift
+    */
+  def toRedshift: Redshift = Redshift((cz / RadialVelocity.C).value)
+
+  override def toString =
+    s"ApparentRadialVelocity(${cz.to[Double, KilometersPerSecond].show})"
+}
+
+object ApparentRadialVelocity {
+
+  /**
+    * Zero ApparentRadialVelocity
+    * @group Constructors
+    */
+  val Zero: ApparentRadialVelocity = new ApparentRadialVelocity(0.withUnit[MetersPerSecond])
+
+  /** @group Typeclass Instances */
+  implicit val order: Order[ApparentRadialVelocity] =
+    Order.by(_.cz)
+
+  /** @group Typeclass Instances */
+  implicit val showRadialVelocity: Show[ApparentRadialVelocity] =
+    Show.fromToString
+
+}

--- a/modules/math/shared/src/main/scala/gsp/math/ProperMotion.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/ProperMotion.scala
@@ -55,7 +55,6 @@ final case class ProperMotion(
 
 }
 
-
 object ProperMotion extends ProperMotionOptics {
   import PhysicalConstants.{ AstronomicalUnit, TwoPi }
 

--- a/modules/math/shared/src/main/scala/gsp/math/Redshift.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Redshift.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import cats._
+import cats.implicits._
+import coulomb._
+import gsp.math.units._
+
+/**
+  * Represents a redshift of an object as it moves away (positive) or towards (negative) the observing point
+  *
+  * Redshift can be (perhaps surprisingly) higher than 1.
+  *
+  * For far objects Redshift can be converted to RadialVelocity which takes into account relativistic effects and cannot be more than C
+  * For nearer objects we can convert to ApparentRadialVelocity which doesn't consider relativistic effects
+  *
+  * Often Redshift is referred as z
+  */
+final case class Redshift(z: BigDecimal) {
+
+  /**
+    * Converts to RadialVelocity, approximate
+    */
+  def toRadialVelocity: Option[RadialVelocity] = {
+    val rv = RadialVelocity.C.value * (((z + 1) * (z + 1) - 1) / ((z + 1) * (z + 1) + 1))
+    RadialVelocity(rv.round(z.mc).withUnit[MetersPerSecond])
+  }
+
+  def toApparentRadialVelocity: ApparentRadialVelocity =
+    ApparentRadialVelocity((RadialVelocity.C.value * z).withUnit[MetersPerSecond])
+
+  override def toString =
+    s"Redshift($z)"
+}
+
+object Redshift {
+
+  /**
+    * The `No redshift`
+    * @group Constructors
+    */
+  val Zero: Redshift = new Redshift(0)
+
+  /** @group Typeclass Instances */
+  implicit val orderRedshift: Order[Redshift] =
+    Order.by(_.z)
+
+  /** @group Typeclass Instances */
+  implicit val showRedshift: Show[Redshift] =
+    Show.fromToString
+
+}

--- a/modules/math/shared/src/main/scala/gsp/math/Redshift.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/Redshift.scala
@@ -41,7 +41,7 @@ object Redshift {
     * The `No redshift`
     * @group Constructors
     */
-  val Zero: Redshift = new Redshift(0)
+  val Zero: Redshift = Redshift(0)
 
   /** @group Typeclass Instances */
   implicit val orderRedshift: Order[Redshift] =

--- a/modules/math/shared/src/main/scala/gsp/math/units.scala
+++ b/modules/math/shared/src/main/scala/gsp/math/units.scala
@@ -16,9 +16,12 @@ import spire.math.Rational
 
 trait units {
   // Wavelength units
-  type Picometer = Pico %* Meter
-  type Nanometer = Nano %* Meter
-  type Angstrom  = Hecto %* Picometer
+  type Picometer            = Pico %* Meter
+  type Nanometer            = Nano %* Meter
+  type Angstrom             = Hecto %* Picometer
+  type CentimetersPerSecond = (Centi %* Meter) %/ Second
+  type MetersPerSecond      = Meter %/ Second
+  type KilometersPerSecond  = (Kilo %* Meter) %/ Second
 
   // Ints greater than zero
   type PositiveInt = Int Refined Positive

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbApparentRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbApparentRadialVelocity.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+package arb
+
+import coulomb._
+import gsp.math.units._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+
+trait ArbApparentRadialVelocity {
+
+  implicit val arbApparentRadialVelocity: Arbitrary[ApparentRadialVelocity] =
+    Arbitrary {
+      for {
+        cz <- arbitrary[BigDecimal]
+      } yield ApparentRadialVelocity(cz.withUnit[MetersPerSecond])
+    }
+
+  implicit val cogRedshift: Cogen[ApparentRadialVelocity] =
+    Cogen[BigDecimal].contramap(_.cz.value)
+}
+
+object ArbApparentRadialVelocity extends ArbApparentRadialVelocity

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbRadialVelocity.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbRadialVelocity.scala
@@ -1,22 +1,27 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package gsp.math.arb
+package gsp.math
+package arb
 
-import gsp.math._
-import gsp.math.syntax.prism._
-import org.scalacheck._
-import org.scalacheck.Arbitrary._
+import coulomb._
+import gsp.math.PhysicalConstants._
+import gsp.math.units._
+import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
+import org.scalacheck.Gen
 
 trait ArbRadialVelocity {
 
   implicit val arbRadialVelocity: Arbitrary[RadialVelocity] =
-    Arbitrary(arbitrary[Short].map(n => RadialVelocity.fromMetersPerSecond.unsafeGet(n.toInt)))
+    Arbitrary {
+      for {
+        rv <- Gen.chooseNum(-SpeedOfLight + 1, SpeedOfLight - 1)
+      } yield RadialVelocity.unsafeFromQuantity(rv.withUnit[MetersPerSecond])
+    }
 
   implicit val cogRadialVelocity: Cogen[RadialVelocity] =
-    Cogen[Int].contramap(_.toMetersPerSecond)
-
+    Cogen[BigDecimal].contramap(_.rv.value)
 }
 
 object ArbRadialVelocity extends ArbRadialVelocity

--- a/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbRedshift.scala
+++ b/modules/testkit/shared/src/main/scala/gsp/math/arb/ArbRedshift.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+package arb
+
+import gsp.math.Redshift
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbRedshift {
+
+  implicit val arbRedshift: Arbitrary[Redshift] =
+    Arbitrary {
+      for {
+        rs <- Gen.chooseNum(-10.0, 10.0)
+      } yield Redshift(rs)
+    }
+
+  implicit val cogRedshift: Cogen[Redshift] =
+    Cogen[BigDecimal].contramap(_.z)
+}
+
+object ArbRedshift extends ArbRedshift

--- a/modules/tests/shared/src/main/scala/gsp/math/ApparentRadialVelocitySpec.scala
+++ b/modules/tests/shared/src/main/scala/gsp/math/ApparentRadialVelocitySpec.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import java.math.MathContext
+
+import cats._
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import gsp.math.arb._
+import gsp.math.units._
+
+final class ApparentRadialVelocitySpec extends CatsSuite {
+  import ArbApparentRadialVelocity._
+
+  // Laws
+  checkAll("ApparentRadialVelocity", EqTests[ApparentRadialVelocity].eqv)
+  checkAll("ApparentRadialVelocityOrder", OrderTests[ApparentRadialVelocity].order)
+
+  test("toRedshift") {
+    assert(
+      // Note the speed is given in Meter per second but coulomb will convert
+      ApparentRadialVelocity(0.withUnit[MetersPerSecond]).toRedshift === Redshift.Zero
+    )
+    assert(ApparentRadialVelocity(RadialVelocity.C).toRedshift === Redshift(1))
+    assert(
+      ApparentRadialVelocity(
+        BigDecimal.decimal(1000, MathContext.DECIMAL32).withUnit[KilometersPerSecond]
+      ).toRedshift === Redshift(BigDecimal.decimal(0.003335641, MathContext.DECIMAL32))
+    )
+  }
+
+  test("Equality must be natural") {
+    forAll { (a: ApparentRadialVelocity, b: ApparentRadialVelocity) =>
+      a.equals(b) shouldEqual Eq[ApparentRadialVelocity].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .cz") {
+    forAll { (a: ApparentRadialVelocity, b: ApparentRadialVelocity) =>
+      Order[BigDecimal].comparison(a.cz.value, b.cz.value) shouldEqual
+        Order[ApparentRadialVelocity].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: ApparentRadialVelocity) =>
+      a.toString shouldEqual Show[ApparentRadialVelocity].show(a)
+    }
+  }
+}

--- a/modules/tests/shared/src/main/scala/gsp/math/RedshiftSpec.scala
+++ b/modules/tests/shared/src/main/scala/gsp/math/RedshiftSpec.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gsp.math
+
+import java.math.MathContext
+
+import cats._
+import cats.kernel.laws.discipline._
+import cats.tests.CatsSuite
+import coulomb._
+import coulomb.si._
+import coulomb.siprefix._
+import gsp.math.arb._
+import gsp.math.units._
+
+final class RedshiftSpec extends CatsSuite {
+  import ArbRedshift._
+
+  // Laws
+  checkAll("Redshift", EqTests[Redshift].eqv)
+  checkAll("RedshiftOrder", OrderTests[Redshift].order)
+
+  test("toRadialVelocity") {
+    assert(Redshift.Zero.toRadialVelocity === RadialVelocity(0.withUnit[MetersPerSecond]))
+    assert(
+      // Example from http://spiff.rit.edu/classes/phys240/lectures/expand/expand.html
+      // We need to specify the Math context to properly compare
+      Redshift(BigDecimal.decimal(5.82, MathContext.DECIMAL64)).toRadialVelocity === RadialVelocity(
+        BigDecimal
+          .decimal(287172.9120288430, MathContext.DECIMAL64)
+          .withUnit[KilometersPerSecond]
+      )
+    )
+  }
+
+  test("toApparentRadialVelocity") {
+    assert(
+      Redshift.Zero.toApparentRadialVelocity === ApparentRadialVelocity(0.withUnit[MetersPerSecond])
+    )
+    assert(Redshift(1).toApparentRadialVelocity === ApparentRadialVelocity(RadialVelocity.C))
+    assert(
+      // In apparent radial velocity we can go faster than C
+      Redshift(
+        BigDecimal.decimal(5.82, MathContext.DECIMAL64)
+      ).toApparentRadialVelocity === ApparentRadialVelocity(
+        BigDecimal
+          .decimal(1744792.10556, MathContext.DECIMAL64)
+          .withUnit[KilometersPerSecond]
+      )
+    )
+  }
+
+  test("Equality must be natural") {
+    forAll { (a: Redshift, b: Redshift) =>
+      a.equals(b) shouldEqual Eq[Redshift].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .z") {
+    forAll { (a: Redshift, b: Redshift) =>
+      Order[BigDecimal].comparison(a.z, b.z) shouldEqual
+        Order[Redshift].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: Redshift) =>
+      a.toString shouldEqual Show[Redshift].show(a)
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/gsp/math/RadialVelocitySpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/RadialVelocitySpec.scala
@@ -3,8 +3,8 @@
 
 package gsp.math
 
+import cats._
 import cats.tests.CatsSuite
-import gsp.math.laws.discipline._
 import gsp.math.arb._
 import monocle.law.discipline._
 
@@ -12,7 +12,26 @@ final class RadialVelocitySpec extends CatsSuite {
   import ArbRadialVelocity._
 
   // Laws
-  checkAll("RadialVelocity.fromMetersPerSecond", PrismTests(RadialVelocity.fromMetersPerSecond))
-  checkAll("RadialVelocity.fromKilometersPerSecond", FormatTests(RadialVelocity.fromKilometersPerSecond).format)
+  checkAll("fromMetersPerSecond", PrismTests(RadialVelocity.fromMetersPerSecond))
+
+  test("Equality must be natural") {
+    forAll { (a: RadialVelocity, b: RadialVelocity) =>
+      a.equals(b) shouldEqual Eq[RadialVelocity].eqv(a, b)
+    }
+  }
+
+  test("Order must be consistent with .rv") {
+    forAll { (a: RadialVelocity, b: RadialVelocity) =>
+      Order[BigDecimal].comparison(a.rv.value, b.rv.value) shouldEqual
+        Order[RadialVelocity].comparison(a, b)
+    }
+  }
+
+  test("Show must be natural") {
+    forAll { (a: RadialVelocity) =>
+      a.toString shouldEqual Show[RadialVelocity].show(a)
+    }
+  }
 
 }
+


### PR DESCRIPTION
`RadialVelocity` from gsp-core really belongs in `gsp-math` as `ProperMotion` uses it. The classes were copied more or less exactly but some methods were added to conform to the `gsp-math` style

these will be removed from `gsp-core` once this is released