### PR TITLE
Increase shape expression test tolerance

### DIFF
--- a/modules/tests/shared/src/test/scala/gsp/math/geom/ShapeExpressionSpec.scala
+++ b/modules/tests/shared/src/test/scala/gsp/math/geom/ShapeExpressionSpec.scala
@@ -79,7 +79,7 @@ final class ShapeExpressionSpec extends CatsSuite {
       val nominal = e.µasSquared
       val rotated = (e ⟲ a).µasSquared
       val error   = if (nominal === 0L) 0L else (nominal - rotated).toDouble / nominal.toDouble
-      error shouldEqual 0.0 +- 1.0e-14
+      error shouldEqual 0.0 +- 1.0e-13
     }
   }
 
@@ -88,7 +88,7 @@ final class ShapeExpressionSpec extends CatsSuite {
       val nominal = e.µasSquared
       val moved   = (e ↗ o).µasSquared
       val error   = if (nominal === 0L) 0L else (nominal - moved).toDouble / nominal.toDouble
-      error shouldEqual 0.0 +- 1.0e-14
+      error shouldEqual 0.0 +- 1.0e-13
     }
   }
 


### PR DESCRIPTION
A small update to address #138.  Due to, presumably, rounding error JTS shape expressions can differ slightly in calculated area after rotation or translation.  This  PR just increases floating point comparison tolerance a tiny bit to accommodate.