### PR TITLE
ObservationReference

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/ObservationReference.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ObservationReference.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.Order
+import cats.parse.Parser
+import cats.parse.Parser.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax.*
+import lucuma.core.optics.Format
+
+/**
+ * An observation reference identifies a particular observation within a
+ * particular program.
+ *
+ * @param programReference program in which the observation is found
+ * @param observationIndex unique immutable index, relative to the program, of
+ *                         the observation
+ */
+case class ObservationReference(
+  programReference: ProgramReference,
+  observationIndex: PosInt
+) {
+
+  /** Formatted observation reference String. */
+  def label: String =
+    f"${programReference.label}-$observationIndex%04d"
+
+}
+
+object ObservationReference {
+
+  object parse {
+    import ProgramReference.parse.programReference
+    import parser.ReferenceParsers.*
+
+    val observation: Parser[ObservationReference] =
+      ((programReference <* dash) ~ index).map { (ref, index) =>
+        ObservationReference(ref, index)
+      }
+  }
+
+  given Order[ObservationReference] =
+    Order.by { a => (a.programReference, a.observationIndex.value) }
+
+  given Ordering[ObservationReference] =
+    Order[ObservationReference].toOrdering
+
+  val fromString: Format[String, ObservationReference] =
+    Format(s => parse.observation.parseAll(s).toOption, _.label)
+
+  given Decoder[ObservationReference] =
+    Decoder.decodeString.emap { s =>
+      fromString
+        .getOption(s)
+        .toRight(s"Could not parse '$s' as an ObservationReference.")
+    }
+
+  given Encoder[ObservationReference] =
+    Encoder.instance(_.label.asJson)
+
+}

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbObservationReference.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbObservationReference.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+package arb
+
+import eu.timepit.refined.types.numeric.PosInt
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+
+trait ArbObservationReference extends ArbReference {
+
+  import ArbProgramReference.given
+
+  given Arbitrary[ObservationReference] =
+    Arbitrary {
+      for {
+        p <- arbitrary[ProgramReference]
+        n <- arbitraryIndex
+      } yield ObservationReference(p, PosInt.unsafeFrom(n))
+    }
+
+  given Cogen[ObservationReference] =
+    Cogen[(ProgramReference, Int)].contramap { a => (
+      a.programReference,
+      a.observationIndex.value
+    )}
+
+  val observationReferenceStrings: Gen[String] =
+    referenceStrings[ObservationReference](_.label)
+
+}
+
+object ArbObservationReference extends ArbObservationReference

--- a/modules/tests/shared/src/test/scala/lucuma/core/model/ObservationReferenceSuite.scala
+++ b/modules/tests/shared/src/test/scala/lucuma/core/model/ObservationReferenceSuite.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model
+
+import cats.kernel.laws.discipline.*
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.model.arb.ArbObservationReference
+import lucuma.core.optics.laws.discipline.*
+
+final class ObservationReferenceSuite extends munit.DisciplineSuite with ArbitraryInstances {
+
+  import ArbObservationReference.given
+  import ArbObservationReference.observationReferenceStrings
+
+  checkAll("ObservationReference", OrderTests[ObservationReference].order)
+  checkAll("ObservationReference", FormatTests(ObservationReference.fromString).formatWith(observationReferenceStrings))
+  checkAll("ObservationReference", CodecTests[ObservationReference].codec)
+}
+


### PR DESCRIPTION
Adds the `ObservationReference` from the [ODB Observation Reference PR](https://github.com/gemini-hlsw/lucuma-odb/pull/1045).  The ODB would be updated to use this version.