### PR TITLE
sc-5667 add arc type

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ArcType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ArcType.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.enums
+
+import lucuma.core.util.Enumerated
+
+/**
+ * Enumerated type for arc types.
+ * @group Enumerations
+ */
+enum ArcType(val tag: String) derives Enumerated:
+  /** @group Constructors */ case Empty extends ArcType("empty")
+  /** @group Constructors */ case Full extends ArcType("full")
+  /** @group Constructors */ case Partial extends ArcType("partial")


### PR DESCRIPTION
This adds an `ArcType` enum that's necessary for json and SLQ encoding.