### PR TITLE
Shortcut 5099: idempotency key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.linker.interface.ESVersion
 
-ThisBuild / tlBaseVersion                         := "0.145"
+ThisBuild / tlBaseVersion                         := "0.146"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/Client.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Client.scala
@@ -6,4 +6,8 @@ package lucuma.core.model
 import lucuma.core.refined.auto.*
 import lucuma.core.util.WithUid
 
+// This should be deprecated but actually doing so causes a hardship in the ODB leaf mapping, which the compiler insists
+// on inlining and reporting the deprecation warning despite the nowarn annotation.
+
+//@deprecated(message = "Use lucuma.core.util.IdempotencyKey instead.")
 object Client extends WithUid('c'.refined)

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExecutionEvent.scala
@@ -14,18 +14,19 @@ import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
 import lucuma.core.refined.auto.*
+import lucuma.core.util.IdempotencyKey
 import lucuma.core.util.Timestamp
 import lucuma.core.util.WithGid
 import monocle.Prism
 import monocle.macros.GenPrism
 
-sealed trait ExecutionEvent derives Eq {
+sealed trait ExecutionEvent derives Eq:
 
-  def id:            ExecutionEvent.Id
-  def received:      Timestamp
-  def observationId: Observation.Id
-  def visitId:       Visit.Id
-  def clientId:      Option[Client.Id]
+  def id:             ExecutionEvent.Id
+  def received:       Timestamp
+  def observationId:  Observation.Id
+  def visitId:        Visit.Id
+  def idempotencyKey: Option[IdempotencyKey]
 
   import ExecutionEvent.*
 
@@ -36,67 +37,64 @@ sealed trait ExecutionEvent derives Eq {
     stepEvent:     StepEvent     => A,
     datasetEvent:  DatasetEvent  => A
   ): A =
-    this match {
+    this match
       case e@SlewEvent(_, _, _, _, _, _)             => slewEvent(e)
       case e@SequenceEvent(_, _, _, _, _, _)         => sequenceEvent(e)
       case e@AtomEvent(_, _, _, _, _, _, _)          => atomEvent(e)
       case e@StepEvent(_, _, _, _, _, _, _, _)       => stepEvent(e)
       case e@DatasetEvent(_, _, _, _, _, _, _, _, _) => datasetEvent(e)
-    }
 
-}
-
-object ExecutionEvent extends WithGid('e'.refined) {
+object ExecutionEvent extends WithGid('e'.refined):
 
   case class SlewEvent(
-    id:            ExecutionEvent.Id,
-    received:      Timestamp,
-    observationId: Observation.Id,
-    visitId:       Visit.Id,
-    clientId:      Option[Client.Id],
-    stage:         SlewStage
+    id:             ExecutionEvent.Id,
+    received:       Timestamp,
+    observationId:  Observation.Id,
+    visitId:        Visit.Id,
+    idempotencyKey: Option[IdempotencyKey],
+    stage:          SlewStage
   ) extends ExecutionEvent derives Eq
 
   case class SequenceEvent(
-    id:            ExecutionEvent.Id,
-    received:      Timestamp,
-    observationId: Observation.Id,
-    visitId:       Visit.Id,
-    clientId:      Option[Client.Id],
-    command:       SequenceCommand
+    id:             ExecutionEvent.Id,
+    received:       Timestamp,
+    observationId:  Observation.Id,
+    visitId:        Visit.Id,
+    idempotencyKey: Option[IdempotencyKey],
+    command:        SequenceCommand
   ) extends ExecutionEvent derives Eq
 
   case class AtomEvent(
-    id:            ExecutionEvent.Id,
-    received:      Timestamp,
-    observationId: Observation.Id,
-    visitId:       Visit.Id,
-    clientId:      Option[Client.Id],
-    atomId:        Atom.Id,
-    stage:         AtomStage
+    id:             ExecutionEvent.Id,
+    received:       Timestamp,
+    observationId:  Observation.Id,
+    visitId:        Visit.Id,
+    idempotencyKey: Option[IdempotencyKey],
+    atomId:         Atom.Id,
+    stage:          AtomStage
   ) extends ExecutionEvent derives Eq
 
   case class StepEvent(
-    id:            ExecutionEvent.Id,
-    received:      Timestamp,
-    observationId: Observation.Id,
-    visitId:       Visit.Id,
-    clientId:      Option[Client.Id],
-    atomId:        Atom.Id,
-    stepId:        Step.Id,
-    stage:         StepStage
+    id:             ExecutionEvent.Id,
+    received:       Timestamp,
+    observationId:  Observation.Id,
+    visitId:        Visit.Id,
+    idempotencyKey: Option[IdempotencyKey],
+    atomId:         Atom.Id,
+    stepId:         Step.Id,
+    stage:          StepStage
   ) extends ExecutionEvent derives Eq
 
   case class DatasetEvent(
-    id:            ExecutionEvent.Id,
-    received:      Timestamp,
-    observationId: Observation.Id,
-    visitId:       Visit.Id,
-    clientId:      Option[Client.Id],
-    atomId:        Atom.Id,
-    stepId:        Step.Id,
-    datasetId:     Dataset.Id,
-    stage:         DatasetStage
+    id:             ExecutionEvent.Id,
+    received:       Timestamp,
+    observationId:  Observation.Id,
+    visitId:        Visit.Id,
+    idempotencyKey: Option[IdempotencyKey],
+    atomId:         Atom.Id,
+    stepId:         Step.Id,
+    datasetId:      Dataset.Id,
+    stage:          DatasetStage
   ) extends ExecutionEvent derives Eq
 
   val atomEvent: Prism[ExecutionEvent, AtomEvent] =
@@ -113,5 +111,3 @@ object ExecutionEvent extends WithGid('e'.refined) {
 
   val stepEvent: Prism[ExecutionEvent, StepEvent] =
     GenPrism[ExecutionEvent, StepEvent]
-
-}

--- a/modules/core/shared/src/main/scala/lucuma/core/util/IdempotencyKey.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/util/IdempotencyKey.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+
+import monocle.Prism
+
+import java.util.UUID
+import scala.util.Try
+
+object IdempotencyKey extends NewType[UUID]:
+
+  val FromString: Prism[String, IdempotencyKey] =
+    def parse(s: String): Option[IdempotencyKey] =
+      Try(UUID.fromString(s)).toOption.map(IdempotencyKey.apply)
+
+    def show(k: IdempotencyKey): String =
+      k.value.toString.toLowerCase
+
+    Prism(parse)(show)
+
+type IdempotencyKey = IdempotencyKey.Type

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExecutionEvent.scala
@@ -12,35 +12,37 @@ import lucuma.core.enums.StepStage
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
+import lucuma.core.util.IdempotencyKey
 import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbGid
+import lucuma.core.util.arb.ArbIdempotencyKey
 import lucuma.core.util.arb.ArbTimestamp
 import lucuma.core.util.arb.ArbUid
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.*
 
-trait ArbExecutionEvent {
+trait ArbExecutionEvent:
 
   import ArbEnumerated.given
   import ArbGid.given
+  import ArbIdempotencyKey.given
   import ArbTimestamp.given
   import ArbUid.given
 
   given Arbitrary[ExecutionEvent.DatasetEvent] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         eid <- arbitrary[ExecutionEvent.Id]
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
         aid <- arbitrary[Atom.Id]
-        cid <- arbitrary[Option[Client.Id]]
+        idm <- arbitrary[Option[IdempotencyKey]]
         sid <- arbitrary[Step.Id]
         did <- arbitrary[Dataset.Id]
         stg <- arbitrary[DatasetStage]
-      } yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, cid, aid, sid, did, stg)
-    }
+      yield ExecutionEvent.DatasetEvent(eid, rec, oid, vid, idm, aid, sid, did, stg)
 
   given Cogen[ExecutionEvent.DatasetEvent] =
     Cogen[(
@@ -48,7 +50,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
-      Option[Client.Id],
+      Option[IdempotencyKey],
       Atom.Id,
       Step.Id,
       Dataset.Id,
@@ -58,7 +60,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
-      a.clientId,
+      a.idempotencyKey,
       a.atomId,
       a.stepId,
       a.datasetId,
@@ -66,16 +68,15 @@ trait ArbExecutionEvent {
     )}
 
   given Arbitrary[ExecutionEvent.SequenceEvent] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         eid <- arbitrary[ExecutionEvent.Id]
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
-        cid <- arbitrary[Option[Client.Id]]
+        idm <- arbitrary[Option[IdempotencyKey]]
         cmd <- arbitrary[SequenceCommand]
-      } yield ExecutionEvent.SequenceEvent(eid, rec, oid, vid, cid, cmd)
-    }
+      yield ExecutionEvent.SequenceEvent(eid, rec, oid, vid, idm, cmd)
 
   given Cogen[ExecutionEvent.SequenceEvent] =
     Cogen[(
@@ -83,28 +84,27 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
-      Option[Client.Id],
+      Option[IdempotencyKey],
       SequenceCommand
     )].contramap { a => (
       a.id,
       a.received,
       a.observationId,
       a.visitId,
-      a.clientId,
+      a.idempotencyKey,
       a.command
     )}
 
   given Arbitrary[ExecutionEvent.SlewEvent] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         eid <- arbitrary[ExecutionEvent.Id]
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
-        cid <- arbitrary[Option[Client.Id]]
+        idm <- arbitrary[Option[IdempotencyKey]]
         stg <- arbitrary[SlewStage]
-      } yield ExecutionEvent.SlewEvent(eid, rec, oid, vid, cid, stg)
-    }
+      yield ExecutionEvent.SlewEvent(eid, rec, oid, vid, idm, stg)
 
   given Cogen[ExecutionEvent.SlewEvent] =
     Cogen[(
@@ -112,29 +112,28 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
-      Option[Client.Id],
+      Option[IdempotencyKey],
       SlewStage
     )].contramap { a => (
       a.id,
       a.received,
       a.observationId,
       a.visitId,
-      a.clientId,
+      a.idempotencyKey,
       a.stage
     )}
 
   given Arbitrary[ExecutionEvent.AtomEvent] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         eid <- arbitrary[ExecutionEvent.Id]
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
-        cid <- arbitrary[Option[Client.Id]]
+        idm <- arbitrary[Option[IdempotencyKey]]
         aid <- arbitrary[Atom.Id]
         stg <- arbitrary[AtomStage]
-      } yield ExecutionEvent.AtomEvent(eid, rec, oid, vid, cid, aid, stg)
-    }
+      yield ExecutionEvent.AtomEvent(eid, rec, oid, vid, idm, aid, stg)
 
   given Cogen[ExecutionEvent.AtomEvent] =
     Cogen[(
@@ -142,7 +141,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
-      Option[Client.Id],
+      Option[IdempotencyKey],
       Atom.Id,
       AtomStage
     )].contramap { a => (
@@ -150,24 +149,23 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
-      a.clientId,
+      a.idempotencyKey,
       a.atomId,
       a.stage
     )}
 
   given Arbitrary[ExecutionEvent.StepEvent] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         eid <- arbitrary[ExecutionEvent.Id]
         rec <- arbitrary[Timestamp]
         oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
         aid <- arbitrary[Atom.Id]
-        cid <- arbitrary[Option[Client.Id]]
+        idm <- arbitrary[Option[IdempotencyKey]]
         sid <- arbitrary[Step.Id]
         stg <- arbitrary[StepStage]
-      } yield ExecutionEvent.StepEvent(eid, rec, oid, vid, cid, aid, sid, stg)
-    }
+      yield ExecutionEvent.StepEvent(eid, rec, oid, vid, idm, aid, sid, stg)
 
   given Cogen[ExecutionEvent.StepEvent] =
     Cogen[(
@@ -175,7 +173,7 @@ trait ArbExecutionEvent {
       Timestamp,
       Observation.Id,
       Visit.Id,
-      Option[Client.Id],
+      Option[IdempotencyKey],
       Atom.Id,
       Step.Id,
       StepStage
@@ -184,7 +182,7 @@ trait ArbExecutionEvent {
       a.received,
       a.observationId,
       a.visitId,
-      a.clientId,
+      a.idempotencyKey,
       a.atomId,
       a.stepId,
       a.stage
@@ -215,6 +213,5 @@ trait ArbExecutionEvent {
       ExecutionEvent.slewEvent.getOption(a),
       ExecutionEvent.stepEvent.getOption(a)
     )}
-}
 
 object ArbExecutionEvent extends ArbExecutionEvent

--- a/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbIdempotencyKey.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/util/arb/ArbIdempotencyKey.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.util
+package arb
+
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+
+import java.util.UUID
+
+trait ArbIdempotencyKey:
+  given arbIdempotencyKey: Arbitrary[IdempotencyKey] =
+    Arbitrary(arbitrary[UUID].map(IdempotencyKey.apply))
+
+  given cogIdempotencyKey: Cogen[IdempotencyKey] =
+    Cogen[UUID].contramap(_.value)
+
+object ArbIdempotencyKey extends ArbIdempotencyKey


### PR DESCRIPTION
@rpiaggio suggested that the name `clientId`, which is a parameter added to mutations to enable an idempotent retry, is misleading.  I searched for a better alternative and came up with the admittedly verbose term `idempotencyKey`.  I've added a UUID new type `IdempotencyKey` to go along with it.  Corresponding changes will be made in the ODB (though I've left the `Client.Id` and the `clientId` parameter in the API until clients can be updated).