### PR TITLE
GHOST detector gross exposure time

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostDetector.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostDetector.scala
@@ -16,7 +16,10 @@ final case class GhostDetector(
   exposureCount:  PosInt,
   binning:        GhostBinning,
   readMode:       GhostReadMode
-)
+):
+  /** The sum of exposure times for all exposures. */
+  def grossExposureTime: TimeSpan =
+    exposureTime *| exposureCount.value
 
 object GhostDetector:
   given Eq[GhostDetector] =

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostDynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostDynamicConfig.scala
@@ -4,13 +4,18 @@
 package lucuma.core.model.sequence.ghost
 
 import cats.Eq
+import cats.syntax.order.*
+import lucuma.core.util.TimeSpan
 
 final case class GhostDynamicConfig(
   redCamera:         GhostDetector.Red,
   blueCamera:        GhostDetector.Blue,
   ifu1FiberAgitator: Ifu1FiberAgitator = Ifu1FiberAgitator.Disabled,
   ifu2FiberAgitator: Ifu2FiberAgitator = Ifu2FiberAgitator.Disabled
-)
+):
+  /** Expected overall exposure time for all exposures of either camera. */
+  def grossExposureTime: TimeSpan =
+    redCamera.value.grossExposureTime max blueCamera.value.grossExposureTime
 
 object GhostDynamicConfig:
   given Eq[GhostDynamicConfig] =


### PR DESCRIPTION
Adds a bit of convenience to compute the overall exposure time expected across the blue and red cameras.  