### PR TITLE
blind offset candidate query failing for gea

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val jtsVersion                 = "0.4.2"
 lazy val kindProjectorVersion       = "0.13.2"
 lazy val kittensVersion             = "3.5.0"
 lazy val log4catsVersion            = "2.8.0"
+lazy val otel4sVersion              = "0.12.0"
 lazy val lucumaRefinedVersion       = "0.1.4"
 lazy val monocleVersion             = "3.3.0"
 lazy val munitVersion               = "1.3.0"
@@ -167,7 +168,8 @@ lazy val catalog = crossProject(JVMPlatform, JSPlatform)
       "org.typelevel" %%% "kittens"              % kittensVersion,
       "edu.gemini"    %%% "clue-core"            % clueVersion,
       "edu.gemini"    %%% "clue-http4s"          % clueVersion,
-      "org.typelevel" %%% "log4cats-core"        % log4catsVersion
+      "org.typelevel" %%% "log4cats-core"        % log4catsVersion,
+      "org.typelevel" %%% "otel4s-core"          % otel4sVersion
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.180"
+ThisBuild / tlBaseVersion                         := "0.181"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/catalog-testkit/jvm/src/main/scala/lucuma/catalog/clients/GaiaClientMock.scala
+++ b/modules/catalog-testkit/jvm/src/main/scala/lucuma/catalog/clients/GaiaClientMock.scala
@@ -13,6 +13,7 @@ import lucuma.catalog.votable.CatalogAdapter
 import org.http4s.*
 import org.http4s.client.Client
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.otel4s.trace.Tracer
 
 import scala.xml.Node
 import scala.xml.Utility
@@ -58,7 +59,7 @@ object GaiaClientMock:
   /**
    * ) Create a mock GaiaClient that returns VOTable XML responses.
    */
-  def mockGaiaClient[F[_]: Concurrent: LoggerFactory](
+  def mockGaiaClient[F[_]: Concurrent: Tracer: LoggerFactory](
     voTableXml: Stream[F, String],
     adapters:   Option[NonEmptyChain[CatalogAdapter.Gaia]] = None
   ): GaiaClient[F] = {
@@ -86,7 +87,7 @@ object GaiaClientMock:
   /**
    * Create a mock GaiaClient that reads XML.
    */
-  def fromXML[F[_]: Concurrent: LoggerFactory](
+  def fromXML[F[_]: Concurrent: Tracer: LoggerFactory](
     xml:      Node,
     adapters: Option[NonEmptyChain[CatalogAdapter.Gaia]]
   ): GaiaClient[F] =
@@ -95,7 +96,7 @@ object GaiaClientMock:
   /**
    * Create a mock GaiaClient that reads a String.
    */
-  def fromString[F[_]: Concurrent: LoggerFactory](
+  def fromString[F[_]: Concurrent: Tracer: LoggerFactory](
     content:  String,
     adapters: Option[NonEmptyChain[CatalogAdapter.Gaia]]
   ): GaiaClient[F] =
@@ -104,7 +105,7 @@ object GaiaClientMock:
   /**
    * Create a mock GaiaClient that reads VOTable XML from a resource file.
    */
-  def fromResource[F[_]: Async: LoggerFactory](
+  def fromResource[F[_]: Async: Tracer: LoggerFactory](
     resource: String,
     adapters: Option[NonEmptyChain[CatalogAdapter.Gaia]]
   ): GaiaClient[F] =

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionApp.scala
@@ -42,6 +42,7 @@ import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 import java.time.Duration
 import java.time.Instant

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionStreamApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/AgsSelectionStreamApp.scala
@@ -21,6 +21,7 @@ import lucuma.core.math.Offset
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 object AgsSelectionSampleStreamApp extends IOApp.Simple with AgsSelectionSample:
 

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
@@ -17,14 +17,17 @@ import lucuma.core.math.Epoch
 import lucuma.core.math.RightAscension
 import lucuma.core.model.SiderealTracking
 import org.http4s.jdkhttpclient.JdkHttpClient
-import org.typelevel.log4cats.LoggerFactory
-import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.log4cats.*
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+import org.http4s.client.middleware.{ResponseLogger => CliLogger}
 
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 
 trait BlindOffsetSample:
+  given LoggerFactory[IO] = Slf4jFactory.create[IO]
+  given L: Logger[IO]     = LoggerFactory[IO].getLoggerFromName("blind-offset-test")
 
   protected val observationTime: Instant =
     LocalDate.of(2025, 9, 4).atStartOfDay(ZoneOffset.UTC).toInstant()
@@ -48,32 +51,37 @@ trait BlindOffsetSample:
     BlindOffsets.runBlindOffsetAnalysis(gaiaClient, siderealTracking, observationTime)
   }
 
-  def printCandidates(candidates: List[BlindOffsetCandidate]): IO[Unit] = IO {
-    println(s"Found ${candidates.length} blind offset star candidates, sorted by score:")
-    println("rank, sourceId, gmag, distance, score")
-
-    candidates.zipWithIndex.foreach { case (candidate, index) =>
-      val rank     = index + 1
-      val sourceId = candidate.sourceId
-      val gMag     = BlindOffsetCandidate.referenceBrightness(candidate.catalogResult) match {
-        case Some(mag) => f"${mag}%5.2f"
-        case None      => " N/A"
-      }
-      val distance = f"${Angle.decimalArcseconds.get(candidate.distance)}%3.1f"
-      val score    = f"${candidate.score}%3.3f"
-      println(f"$rank%4d, $sourceId%18s, $gMag%5s, ${distance} arcsec, $score%6s")
-    }
-
-  }
+  def printCandidates(candidates: List[BlindOffsetCandidate]): IO[Unit] =
+    L.info(s"Found ${candidates.length} blind offset star candidates, sorted by score:") *>
+      L.info(f"rank, ${"sourceId"}%28s,  gmag, ${"distance"}%4s, score") *>
+      candidates.zipWithIndex.traverse_ : (candidate, index) =>
+        val rank     = index + 1
+        val sourceId = candidate.sourceId
+        val gMag     = BlindOffsetCandidate.referenceBrightness(candidate.catalogResult) match {
+          case Some(mag) => f"${mag}%5.2f"
+          case None      => " N/A"
+        }
+        val distance = f"${Angle.decimalArcseconds.get(candidate.distance)}%3.1f"
+        val score    = f"${candidate.score}%3.3f"
+        val msg      = f"$rank%4d, $sourceId%18s, $gMag%5s, ${distance} arcsec, $score%6s"
+        L.info(msg)
 
 object BlindOffsetApp extends IOApp.Simple with BlindOffsetSample:
 
-  given LoggerFactory[IO] = NoOpFactory[IO]
+  val loggerClient = CliLogger[IO](
+    logHeaders = true,
+    logBody = false
+  )
 
   def run =
     JdkHttpClient
       .simple[IO]
-      .map(GaiaClient.build[IO](_, adapters = NonEmptyChain.of[Gaia](Gaia3LiteGavo)))
+      .map(c =>
+        GaiaClient.build[IO](
+          loggerClient(c),
+          adapters = NonEmptyChain.of[Gaia](Gaia3Esa)
+        )
+      )
       .use: gaiaClient =>
         for {
           _          <- IO.println(s"Querying blind offset star candidates on: $coords")

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
@@ -79,7 +79,7 @@ object BlindOffsetApp extends IOApp.Simple with BlindOffsetSample:
       .map(c =>
         GaiaClient.build[IO](
           loggerClient(c),
-          adapters = NonEmptyChain.of[Gaia](Gaia3Esa)
+          adapters = NonEmptyChain.of[Gaia](Gaia3EsaProxy)
         )
       )
       .use: gaiaClient =>

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/BlindOffsetApp.scala
@@ -16,10 +16,11 @@ import lucuma.core.math.Declination
 import lucuma.core.math.Epoch
 import lucuma.core.math.RightAscension
 import lucuma.core.model.SiderealTracking
+import org.http4s.client.middleware.ResponseLogger as CliLogger
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.*
 import org.typelevel.log4cats.slf4j.Slf4jFactory
-import org.http4s.client.middleware.{ResponseLogger => CliLogger}
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 import java.time.Instant
 import java.time.LocalDate

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/DataLabQueryApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/DataLabQueryApp.scala
@@ -18,6 +18,7 @@ import lucuma.core.math.RightAscension
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 object DataLabQueryApp extends IOApp.Simple:
 

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GaiaQueryApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GaiaQueryApp.scala
@@ -19,6 +19,7 @@ import lucuma.core.math.RightAscension
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 trait GaiaQuerySample {
   val epoch = Epoch.fromString.getOption("J2016.000").getOrElse(Epoch.J2000)

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GaiaQueryPMApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GaiaQueryPMApp.scala
@@ -23,6 +23,7 @@ import lucuma.core.model.SiderealTracking
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 trait GaiaQueryPMSample {
   val epoch = Epoch.fromString.getOption("J2022.000").getOrElse(Epoch.J2000)

--- a/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GhostAgsSelectionApp.scala
+++ b/modules/catalog-tests/jvm/src/main/scala/lucuma/catalog/GhostAgsSelectionApp.scala
@@ -13,6 +13,7 @@ import lucuma.core.geom.pwfs.patrolField
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 object GhostAgsSelectionApp extends IOApp.Simple with AgsSelectionSample {
 

--- a/modules/catalog-tests/jvm/src/test/scala/lucuma/ags/7060.scala
+++ b/modules/catalog-tests/jvm/src/test/scala/lucuma/ags/7060.scala
@@ -41,6 +41,7 @@ import lucuma.core.syntax.all.*
 import munit.CatsEffectSuite
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 import java.time.Instant
 

--- a/modules/catalog-tests/jvm/src/test/scala/lucuma/catalog/clients/GaiaClientSuite.scala
+++ b/modules/catalog-tests/jvm/src/test/scala/lucuma/catalog/clients/GaiaClientSuite.scala
@@ -29,6 +29,7 @@ import lucuma.core.syntax.all.*
 import munit.CatsEffectSuite
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import org.typelevel.otel4s.trace.Tracer.Implicits.noop
 
 class GaiaClientSuite extends CatsEffectSuite with VoTableSamples:
 

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
@@ -15,6 +15,7 @@ import lucuma.core.model.Target
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.otel4s.trace.Tracer
 
 trait GaiaClient[F[_]]:
   /**
@@ -42,7 +43,7 @@ trait GaiaClient[F[_]]:
   def queryByIdGuideStar(sourceId: Long): F[EitherNec[CatalogProblem, Target.Sidereal]]
 
 object GaiaClient:
-  inline def build[F[_]: Concurrent: LoggerFactory](
+  inline def build[F[_]: Concurrent: Tracer: LoggerFactory](
     httpClient: Client[F],
     modUri:     Uri => Uri = identity, // Override this if you need to add a CORS proxy
     adapters:   NonEmptyChain[CatalogAdapter.Gaia] = DefaultAdapters

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
@@ -69,5 +69,5 @@ object GaiaClient:
     NonEmptyChain.of(
       CatalogAdapter.Gaia3DataLab,
       CatalogAdapter.Gaia3LiteGavo,
-      CatalogAdapter.Gaia3LiteEsaProxy
+      CatalogAdapter.Gaia3Esa
     )

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClient.scala
@@ -70,5 +70,5 @@ object GaiaClient:
     NonEmptyChain.of(
       CatalogAdapter.Gaia3DataLab,
       CatalogAdapter.Gaia3LiteGavo,
-      CatalogAdapter.Gaia3Esa
+      CatalogAdapter.Gaia3EsaProxy
     )

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClientImpl.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/clients/GaiaClientImpl.scala
@@ -21,11 +21,12 @@ import org.http4s.client.Client
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.syntax.*
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.Tracer
 
 import java.net.URLDecoder
 
-// TODO Add Trace, we need natchez
-class GaiaClientImpl[F[_]: {Concurrent, LoggerFactory as LF}](
+class GaiaClientImpl[F[_]: {Concurrent, Tracer as T, LoggerFactory as LF}](
   httpClient: Client[F],
   modUri:     Uri => Uri = identity, // Override this if you need to add a CORS proxy
   adapters:   NonEmptyChain[CatalogAdapter.Gaia] = GaiaClient.DefaultAdapters
@@ -80,17 +81,19 @@ class GaiaClientImpl[F[_]: {Concurrent, LoggerFactory as LF}](
     val headers             = Headers(adapter.requestHeaders.map((x, y) => Header.Raw(x, y)).toList)
     val request: Request[F] = Request[F](Method.GET, modUri(queryUri), headers = headers)
 
-    info"Querying catalog: ${adapter.adapterName}, uri: ${URLDecoder.decode(queryUri.renderString, "UTF-8")}" *>
-      info"curl ${headers.headers.map(h => s"-H '${h.name}: ${h.value}'").mkString(" ")} '${queryUri.renderString}'" *>
-      httpClient
-        .stream(request)
-        .flatMap:
-          _.body
-            .through(fs2.text.utf8.decode)
-            .through(parser)
-        .compile
-        .toList
-        .tupleLeft(adapter)
+    T.span("query gaia", Attribute("adapter", adapter.adapterName))
+      .surround:
+        info"Querying catalog: ${adapter.adapterName}, uri: ${URLDecoder.decode(queryUri.renderString, "UTF-8")}" *>
+          info"curl ${headers.headers.map(h => s"-H '${h.name}: ${h.value}'").mkString(" ")} '${queryUri.renderString}'" *>
+          httpClient
+            .stream(request)
+            .flatMap:
+              _.body
+                .through(fs2.text.utf8.decode)
+                .through(parser)
+            .compile
+            .toList
+            .tupleLeft(adapter)
 
   /**
    * Takes a search query and builds a uri to query gaia.

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/votable/CatalogAdapter.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/votable/CatalogAdapter.scala
@@ -594,6 +594,7 @@ object CatalogAdapter {
     lazy val alternateIdField: FieldId =
       FieldId.unsafeFrom("source_id", VoTableParser.UCD_OBJID)
   }
+
   object Gaia3Esa extends Gaia3Esa
 
   trait Gaia3Lite extends Gaia {
@@ -641,8 +642,7 @@ object CatalogAdapter {
     override lazy val uri: Uri       = uri"https://gaia.noirlab.edu/tap-server/tap/sync"
   }
 
-  object Gaia3EsaProxy
-      extends Gaia3Esa { // Do not use with a proxy. This is already a proxy.
+  object Gaia3EsaProxy extends Gaia3Esa { // Do not use with a proxy. This is already a proxy.
     override val adapterName: String = "NoirLab"
     override lazy val uri: Uri       = uri"https://gaia.noirlab.edu/tap-server/tap/sync"
   }

--- a/modules/catalog/shared/src/main/scala/lucuma/catalog/votable/CatalogAdapter.scala
+++ b/modules/catalog/shared/src/main/scala/lucuma/catalog/votable/CatalogAdapter.scala
@@ -589,11 +589,12 @@ object CatalogAdapter {
 
   }
 
-  object Gaia3Esa extends GaiaEsa {
+  trait Gaia3Esa extends GaiaEsa {
     override lazy val gaiaDB: String   = "gaiadr3.gaia_source"
     lazy val alternateIdField: FieldId =
       FieldId.unsafeFrom("source_id", VoTableParser.UCD_OBJID)
   }
+  object Gaia3Esa extends Gaia3Esa
 
   trait Gaia3Lite extends Gaia {
     def alternateIdField: FieldId
@@ -636,6 +637,12 @@ object CatalogAdapter {
 
   object Gaia3LiteEsaProxy
       extends Gaia3LiteEsa { // Do not use with a proxy. This is already a proxy.
+    override val adapterName: String = "NoirLab Lite"
+    override lazy val uri: Uri       = uri"https://gaia.noirlab.edu/tap-server/tap/sync"
+  }
+
+  object Gaia3EsaProxy
+      extends Gaia3Esa { // Do not use with a proxy. This is already a proxy.
     override val adapterName: String = "NoirLab"
     override lazy val uri: Uri       = uri"https://gaia.noirlab.edu/tap-server/tap/sync"
   }


### PR DESCRIPTION
Blind offset search over gaia lite were failing due to the use of the coulmn `astrometric_excess_noise` which is not present on gaia lite. The fix is to switch to plain gaia.

Also tracing was added