### PR TITLE
Shortcut 8293: Add guide and slit viewing camera times

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.182"
+ThisBuild / tlBaseVersion                         := "0.183"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostStaticConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostStaticConfig.scala
@@ -4,14 +4,14 @@
 package lucuma.core.model.sequence.ghost
 
 import cats.Eq
+import cats.derived.*
 import lucuma.core.enums.GhostResolutionMode
+import lucuma.core.util.TimeSpan
 
 // Will the target mode (single vs dual, which if any is sky, etc.) go here?
 
 final case class GhostStaticConfig(
-  resolutionMode: GhostResolutionMode
-)
-
-object GhostStaticConfig:
-  given Eq[GhostStaticConfig] =
-    Eq.by(_.resolutionMode)
+  resolutionMode:                GhostResolutionMode,
+  guideCameraExposureTime:       Option[TimeSpan],
+  slitViewingCameraExposureTime: Option[TimeSpan]
+) derives Eq

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostStaticConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostStaticConfig.scala
@@ -12,6 +12,5 @@ import lucuma.core.util.TimeSpan
 
 final case class GhostStaticConfig(
   resolutionMode:                GhostResolutionMode,
-  guideCameraExposureTime:       Option[TimeSpan],
   slitViewingCameraExposureTime: Option[TimeSpan]
 ) derives Eq

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostStaticConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostStaticConfig.scala
@@ -6,7 +6,9 @@ package ghost
 package arb
 
 import lucuma.core.enums.GhostResolutionMode
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.ArbTimeSpan
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
@@ -14,12 +16,26 @@ import org.scalacheck.Cogen
 trait ArbGhostStaticConfig:
 
   import ArbEnumerated.given
+  import ArbTimeSpan.given
 
   given Arbitrary[GhostStaticConfig] =
     Arbitrary:
-      arbitrary[GhostResolutionMode].map(GhostStaticConfig.apply)
+      for
+        r <- arbitrary[GhostResolutionMode]
+        g <- arbitrary[Option[TimeSpan]]
+        s <- arbitrary[Option[TimeSpan]]
+      yield GhostStaticConfig(r, g, s)
 
   given Cogen[GhostStaticConfig] =
-    Cogen[GhostResolutionMode].contramap(_.resolutionMode)
+    Cogen[(
+      GhostResolutionMode,
+      Option[TimeSpan],
+      Option[TimeSpan]
+    )].contramap: a =>
+      (
+        a.resolutionMode,
+        a.guideCameraExposureTime,
+        a.slitViewingCameraExposureTime
+      )
 
 object ArbGhostStaticConfig extends ArbGhostStaticConfig

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostStaticConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostStaticConfig.scala
@@ -22,19 +22,16 @@ trait ArbGhostStaticConfig:
     Arbitrary:
       for
         r <- arbitrary[GhostResolutionMode]
-        g <- arbitrary[Option[TimeSpan]]
         s <- arbitrary[Option[TimeSpan]]
-      yield GhostStaticConfig(r, g, s)
+      yield GhostStaticConfig(r, s)
 
   given Cogen[GhostStaticConfig] =
     Cogen[(
       GhostResolutionMode,
-      Option[TimeSpan],
       Option[TimeSpan]
     )].contramap: a =>
       (
         a.resolutionMode,
-        a.guideCameraExposureTime,
         a.slitViewingCameraExposureTime
       )
 


### PR DESCRIPTION
Adds the optional guide and slit viewing camera exposure times to the GHOST static configuration.  These are engineering parameters, as I understand it, which are only set by Observe when specified.