### PR TITLE
Shortcut 8293: Order by overall detector estimate

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DetectorEstimate.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/DetectorEstimate.scala
@@ -38,6 +38,7 @@ object DetectorEstimate {
 
   given Order[DetectorEstimate] =
     Order.by { e => (
+      e.estimate,
       e.dataset,
       e.count.value,
       e.name,


### PR DESCRIPTION
In the case of instruments with multiple detectors, all working simultaneously in a single step, we will estimate the overall cost of the step based on the contribution of the most costly detector.  The `Order` implementation did not take into account the dataset count factor, so we were comparing based only on the time for a single dataset.

For example, given

```
Red 10 seconds x 2 
Blue 5 seconds x 5
```

we would select Red (20 seconds total) instead of Blue (25 seconds total) for the cost estimate.