### PR TITLE
Remove coadds from ETM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.186"
+ThisBuild / tlBaseVersion                         := "0.187"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/ExposureTimeMode.scala
@@ -30,26 +30,20 @@ object ExposureTimeMode:
   final case class TimeAndCountMode(
     time:   TimeSpan,
     count:  PosInt,
-    coadds: PosInt,
     at:     Wavelength
-  ) extends ExposureTimeMode:
-    lazy val totalCount: PosInt = PosInt.unsafeFrom(count.value * coadds.value)
+  ) extends ExposureTimeMode
 
   object TimeAndCountMode:
-    def apply(time: TimeSpan, count: PosInt, at: Wavelength): TimeAndCountMode =
-      new TimeAndCountMode(time, count, coadds = PosInt.unsafeFrom(1), at)
-
     val time: Lens[TimeAndCountMode, TimeSpan] = Focus[TimeAndCountMode](_.time)
     val count: Lens[TimeAndCountMode, PosInt]  = Focus[TimeAndCountMode](_.count)
-    val coadds: Lens[TimeAndCountMode, PosInt] = Focus[TimeAndCountMode](_.coadds)
     val at: Lens[TimeAndCountMode, Wavelength] = Focus[TimeAndCountMode](_.at)
-    given Eq[TimeAndCountMode]                 = Eq.by(a => (a.time, a.count, a.coadds, a.at))
+    given Eq[TimeAndCountMode]                 = Eq.by(a => (a.time, a.count, a.at))
 
   given Eq[ExposureTimeMode] =
     Eq.instance:
-      case (a @ SignalToNoiseMode(_, _), b @ SignalToNoiseMode(_, _))           => a === b
-      case (a @ TimeAndCountMode(_, _, _, _), b @ TimeAndCountMode(_, _, _, _)) => a === b
-      case _                                                                    => false
+      case (a @ SignalToNoiseMode(_, _), b @ SignalToNoiseMode(_, _))      => a === b
+      case (a @ TimeAndCountMode(_, _,  _), b @ TimeAndCountMode(_, _, _)) => a === b
+      case _                                                               => false
 
   val signalToNoise: Prism[ExposureTimeMode, SignalToNoiseMode] =
     GenPrism[ExposureTimeMode, SignalToNoiseMode]
@@ -59,11 +53,11 @@ object ExposureTimeMode:
 
   val at: Lens[ExposureTimeMode, Wavelength] =
     Lens[ExposureTimeMode, Wavelength] {
-      case SignalToNoiseMode(_, w)      => w
-      case TimeAndCountMode(_, _, _, w) => w
+      case SignalToNoiseMode(_, w)   => w
+      case TimeAndCountMode(_, _, w) => w
     } { w =>
       {
-        case a @ SignalToNoiseMode(_, _)      => SignalToNoiseMode.at.replace(w)(a)
-        case a @ TimeAndCountMode(_, _, _, _) => TimeAndCountMode.at.replace(w)(a)
+        case a @ SignalToNoiseMode(_, _)   => SignalToNoiseMode.at.replace(w)(a)
+        case a @ TimeAndCountMode(_, _, _) => TimeAndCountMode.at.replace(w)(a)
       }
     }

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExposureTimeMode.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbExposureTimeMode.scala
@@ -42,16 +42,14 @@ trait ArbExposureTimeMode:
       for
         t <- arbitrary[TimeSpan]
         c <- arbitrary[PosInt]
-        a <- arbitrary[PosInt]
         w <- arbitrary[Wavelength]
-      yield TimeAndCountMode(t, c, a, w)
+      yield TimeAndCountMode(t, c, w)
 
   given Cogen[TimeAndCountMode] =
-    Cogen[(TimeSpan, PosInt, PosInt, Wavelength)].contramap: a =>
+    Cogen[(TimeSpan, PosInt, Wavelength)].contramap: a =>
       (
         a.time,
         a.count,
-        a.coadds,
         a.at
       )
 


### PR DESCRIPTION
Upon further analysis, it's probably better not to model the `coadds` as part of the ETM.