### PR TITLE
Initial GHOST configuration

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/Configuration.scala
@@ -53,15 +53,18 @@ object Configuration:
           (conds.cloudExtinction, conds.imageQuality, conds.skyBackground, conds.waterVapor)
 
   sealed abstract class ObservingMode(val tpe: ObservingModeType, val radius: Angle):
-    def gmosNorthLongSlit:  Option[GmosNorthLongSlit   ] = Some(this).collect { case m: GmosNorthLongSlit    => m }
-    def gmosSouthLongSlit:  Option[GmosSouthLongSlit   ] = Some(this).collect { case m: GmosSouthLongSlit    => m }
-    def gmosNorthImaging:   Option[GmosNorthImaging    ] = Some(this).collect { case m: GmosNorthImaging     => m }
-    def gmosSouthImaging:   Option[GmosSouthImaging    ] = Some(this).collect { case m: GmosSouthImaging     => m }
     def flamingos2LongSlit: Option[Flamingos2LongSlit  ] = Some(this).collect { case m: Flamingos2LongSlit   => m }
+    def ghostIfu:           Option[GhostIfu.type       ] = Some(this).collect { case m: GhostIfu.type        => m }
+    def gmosNorthImaging:   Option[GmosNorthImaging    ] = Some(this).collect { case m: GmosNorthImaging     => m }
+    def gmosNorthLongSlit:  Option[GmosNorthLongSlit   ] = Some(this).collect { case m: GmosNorthLongSlit    => m }
+    def gmosSouthImaging:   Option[GmosSouthImaging    ] = Some(this).collect { case m: GmosSouthImaging     => m }
+    def gmosSouthLongSlit:  Option[GmosSouthLongSlit   ] = Some(this).collect { case m: GmosSouthLongSlit    => m }
     def igrins2LongSlit:    Option[Igrins2LongSlit.type] = Some(this).collect { case m: Igrins2LongSlit.type => m }
 
     def subsumes(other: ObservingMode): Boolean =
       (this, other) match
+        case (Flamingos2LongSlit(d1), Flamingos2LongSlit(d2)) => d1 === d2
+        case (GhostIfu,               GhostIfu)               => true
         case (GmosNorthLongSlit(g1),  GmosNorthLongSlit(g2))  => g1 === g2
         case (GmosSouthLongSlit(g1),  GmosSouthLongSlit(g2))  => g1 === g2
 
@@ -72,21 +75,22 @@ object Configuration:
         case (GmosNorthImaging(f1),   GmosNorthImaging(f2))   => true // f2.forall(f1.contains)
         case (GmosSouthImaging(f1),   GmosSouthImaging(f2))   => true // f2.forall(f1.contains)
 
-        case (Flamingos2LongSlit(d1), Flamingos2LongSlit(d2)) => d1 === d2
         case (Igrins2LongSlit,        Igrins2LongSlit)        => true
         case _                                                => false
 
   object ObservingMode:
 
     object Radii:
+      val Flamingos2LongSlit = flamingos2.scienceArea.shapeAt(Angle.Angle0, Offset.Zero, Flamingos2LyotWheel.F16, Flamingos2FpuMask.Imaging).eval.radius
+      val GhostIfu           = ghost.scienceArea.fov.eval.radius
       val GmosLongSlit       = gmos.scienceArea.longSlitFov(Angle.fromMicroarcseconds(2L)).eval.radius // width doesn't matter but should be > 1 µas
       val GmosImaging        = gmos.scienceArea.imaging.eval.radius
-      val Flamingos2LongSlit = flamingos2.scienceArea.shapeAt(Angle.Angle0, Offset.Zero, Flamingos2LyotWheel.F16, Flamingos2FpuMask.Imaging).eval.radius
       val Igrins2LongSlit    = igrins2.scienceArea.scienceSlitFOV.eval.radius
 
-    case class GmosNorthLongSlit(grating: GmosNorthGrating) extends ObservingMode(ObservingModeType.GmosNorthLongSlit, Radii.GmosLongSlit)
-    case class GmosSouthLongSlit(grating: GmosSouthGrating) extends ObservingMode(ObservingModeType.GmosSouthLongSlit, Radii.GmosLongSlit)
-    case class GmosNorthImaging(filters: List[GmosNorthFilter]) extends ObservingMode(ObservingModeType.GmosNorthImaging, Radii.GmosImaging)
-    case class GmosSouthImaging(filters: List[GmosSouthFilter]) extends ObservingMode(ObservingModeType.GmosSouthImaging, Radii.GmosImaging)
     case class Flamingos2LongSlit(disperser: Flamingos2Disperser) extends ObservingMode(ObservingModeType.Flamingos2LongSlit, Radii.Flamingos2LongSlit)
+    case object GhostIfu extends ObservingMode(ObservingModeType.GhostIfu, Radii.GhostIfu)
+    case class GmosNorthImaging(filters: List[GmosNorthFilter]) extends ObservingMode(ObservingModeType.GmosNorthImaging, Radii.GmosImaging)
+    case class GmosNorthLongSlit(grating: GmosNorthGrating) extends ObservingMode(ObservingModeType.GmosNorthLongSlit, Radii.GmosLongSlit)
+    case class GmosSouthImaging(filters: List[GmosSouthFilter]) extends ObservingMode(ObservingModeType.GmosSouthImaging, Radii.GmosImaging)
+    case class GmosSouthLongSlit(grating: GmosSouthGrating) extends ObservingMode(ObservingModeType.GmosSouthLongSlit, Radii.GmosLongSlit)
     case object Igrins2LongSlit extends ObservingMode(ObservingModeType.Igrins2LongSlit, Radii.Igrins2LongSlit)

--- a/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/arb/ArbConfiguration.scala
@@ -39,6 +39,12 @@ trait ArbConfiguration:
     Cogen[(CloudExtinction.Preset, ImageQuality.Preset, SkyBackground, WaterVapor)]
       .contramap(c => (c.cloudExtinction,c.imageQuality,  c.skyBackground, c.waterVapor))
 
+  given Arbitrary[ObservingMode.GhostIfu.type] =
+    Arbitrary(Gen.const(ObservingMode.GhostIfu))
+
+  given Cogen[ObservingMode.GhostIfu.type] =
+    Cogen.cogenUnit.contramap(_ => ())
+
   given Arbitrary[ObservingMode.GmosNorthLongSlit] =
     Arbitrary:
       arbitrary[GmosNorthGrating].map(ObservingMode.GmosNorthLongSlit.apply)
@@ -83,11 +89,12 @@ trait ArbConfiguration:
   given Arbitrary[ObservingMode] =
     Arbitrary:
       Gen.oneOf(
-        arbitrary[ObservingMode.GmosNorthLongSlit],
-        arbitrary[ObservingMode.GmosSouthLongSlit],
-        arbitrary[ObservingMode.GmosNorthImaging],
-        arbitrary[ObservingMode.GmosSouthImaging],
         arbitrary[ObservingMode.Flamingos2LongSlit],
+        arbitrary[ObservingMode.GhostIfu.type],
+        arbitrary[ObservingMode.GmosNorthImaging],
+        arbitrary[ObservingMode.GmosNorthLongSlit],
+        arbitrary[ObservingMode.GmosSouthImaging],
+        arbitrary[ObservingMode.GmosSouthLongSlit],
         arbitrary[ObservingMode.Igrins2LongSlit.type]
       )
 
@@ -97,11 +104,12 @@ trait ArbConfiguration:
   given Cogen[ObservingMode] =
     Cogen: (s, m) =>
       m match
-        case m: ObservingMode.GmosNorthLongSlit    => perturb(s, m)
-        case m: ObservingMode.GmosSouthLongSlit    => perturb(s, m)
-        case m: ObservingMode.GmosNorthImaging     => perturb(s, m)
-        case m: ObservingMode.GmosSouthImaging     => perturb(s, m)
         case m: ObservingMode.Flamingos2LongSlit   => perturb(s, m)
+        case m: ObservingMode.GhostIfu.type        => perturb(s, m)
+        case m: ObservingMode.GmosNorthImaging     => perturb(s, m)
+        case m: ObservingMode.GmosNorthLongSlit    => perturb(s, m)
+        case m: ObservingMode.GmosSouthImaging     => perturb(s, m)
+        case m: ObservingMode.GmosSouthLongSlit    => perturb(s, m)
         case m: ObservingMode.Igrins2LongSlit.type => perturb(s, m)
 
   given Arbitrary[Configuration] =


### PR DESCRIPTION
Adds at least a placeholder for GHOST to the configuration request model.  I don't know if there is anything instrument-specific in particular that needs to be approved when changed (resolution mode?) but this will enable an ODB update that will make the configuration request work for conditions and targets for GHOST observations.