### PR TITLE
Add missing centralWavelength to GnirsDynamicConfig; filter resolution for spectroscopy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.188"
+ThisBuild / tlBaseVersion                         := "0.189"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Flamingos2Filter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Flamingos2Filter.scala
@@ -20,16 +20,16 @@ enum Flamingos2Filter(
   val wavelength: Wavelength,
   val supportsSpectroscopy: Boolean
 ) derives Enumerated:
-  case Y      extends Flamingos2Filter("Y",      "Y",       "Y (1.02 um)",        1020000.pm, true)
-  case J      extends Flamingos2Filter("J",      "J",       "J (1.25 um)",        1250000.pm, true)
-  case H      extends Flamingos2Filter("H",      "H",       "H (1.65 um)",        1650000.pm, true)
-  case JH     extends Flamingos2Filter("JH",     "JH",      "JH (spectroscopic)", 1390000.pm, true)
-  case HK     extends Flamingos2Filter("HK",     "HK",      "HK (spectroscopic)", 1871000.pm, true)
-  case JLow   extends Flamingos2Filter("JLow",   "J-low",   "J-low (1.15 um)",    1150000.pm, true)
-  case KLong  extends Flamingos2Filter("KLong",  "K-long",  "K-long (2.20 um)",   2200000.pm, true)
-  case KShort extends Flamingos2Filter("KShort", "K-short", "K-short (2.15 um)",  2150000.pm, true)
-  case KBlue  extends Flamingos2Filter("KBlue",  "K-blue",  "K-blue (2.06 um)",   2060000.pm, false)
-  case KRed   extends Flamingos2Filter("KRed",   "K-red",   "K-red (2.31 um)",    2310000.pm, false)
+  case Y      extends Flamingos2Filter("Y",      "Y",       "Y (1.02 um)",        1_020_000.pm, true)
+  case J      extends Flamingos2Filter("J",      "J",       "J (1.25 um)",        1_250_000.pm, true)
+  case H      extends Flamingos2Filter("H",      "H",       "H (1.65 um)",        1_650_000.pm, true)
+  case JH     extends Flamingos2Filter("JH",     "JH",      "JH (spectroscopic)", 1_390_000.pm, true)
+  case HK     extends Flamingos2Filter("HK",     "HK",      "HK (spectroscopic)", 1_871_000.pm, true)
+  case JLow   extends Flamingos2Filter("JLow",   "J-low",   "J-low (1.15 um)",    1_150_000.pm, true)
+  case KLong  extends Flamingos2Filter("KLong",  "K-long",  "K-long (2.20 um)",   2_200_000.pm, true)
+  case KShort extends Flamingos2Filter("KShort", "K-short", "K-short (2.15 um)",  2_150_000.pm, true)
+  case KBlue  extends Flamingos2Filter("KBlue",  "K-blue",  "K-blue (2.06 um)",   2_060_000.pm, false)
+  case KRed   extends Flamingos2Filter("KRed",   "K-red",   "K-red (2.31 um)",    2_310_000.pm, false)
 
 object Flamingos2Filter:
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -4,10 +4,13 @@
 package lucuma
 package core
 package enums
+
+import cats.syntax.all.*
 import lucuma.core.math.Wavelength
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 
+import ConvenienceOps.*
 
 /**
  * Enumerated type for GNIRS Filter.
@@ -17,19 +20,29 @@ enum GnirsFilter(
   val tag: String,
   val shortName: String,
   val longName: String,
-  val waveLength: Option[Wavelength]
+  val waveLength: Option[Wavelength],
+  val spectroscopyCutoffWavelength: Option[Wavelength]
 ) derives Enumerated, Display:
-  case CrossDispersed extends GnirsFilter("CrossDispersed", "XD", "Cross dispersed", Option.empty[Wavelength])
-  case Order6 extends GnirsFilter("Order6", "X", "Order 6 (X)", Some(Wavelength.unsafeFromIntPicometers(1100000)))
-  case Order5 extends GnirsFilter("Order5", "J", "Order 5 (J)", Some(Wavelength.unsafeFromIntPicometers(1250000)))
-  case Order4 extends GnirsFilter("Order4", "H", "Order 4 (H: 1.65µm)", Some(Wavelength.unsafeFromIntPicometers(1650000)))
-  case Order3 extends GnirsFilter("Order3", "K", "Order 3 (K)", Some(Wavelength.unsafeFromIntPicometers(2200000)))
-  case Order2 extends GnirsFilter("Order2", "L", "Order 2 (L)", Some(Wavelength.unsafeFromIntPicometers(3500000)))
-  case Order1 extends GnirsFilter("Order1", "M", "Order 1 (M)", Some(Wavelength.unsafeFromIntPicometers(4800000)))
-  case H2 extends GnirsFilter("H2", "H2", "H2: 2.12µm", Some(Wavelength.unsafeFromIntPicometers(2120000)))
-  case HNd100x extends GnirsFilter("HNd100x", "H+ND100X", "H + ND100X", Some(Wavelength.unsafeFromIntPicometers(1650000)))
-  case H2Nd100x extends GnirsFilter("H2Nd100x", "H2+ND100X", "H2 + ND100X", Some(Wavelength.unsafeFromIntPicometers(2120000)))
-  case PAH extends GnirsFilter("PAH", "PAH", "PAH: 3.3µm", Some(Wavelength.unsafeFromIntPicometers(3300000)))
-  case Y extends GnirsFilter("Y", "Y", "Y: 1.03µm", Some(Wavelength.unsafeFromIntPicometers(1030000)))
-  case J extends GnirsFilter("J", "J", "J: 1.25µm", Some(Wavelength.unsafeFromIntPicometers(1250000)))
-  case K extends GnirsFilter("K", "K", "K: 2.20µm", Some(Wavelength.unsafeFromIntPicometers(2200000)))
+  case CrossDispersed extends GnirsFilter("CrossDispersed", "XD", "Cross dispersed", none, none)
+  case Order6 extends GnirsFilter("Order6", "X", "Order 6 (X)", 1_100_000.pm.some, 1_170_000.pm.some)
+  case Order5 extends GnirsFilter("Order5", "J", "Order 5 (J)", 1_250_000.pm.some, 1_420_000.pm.some)
+  case Order4 extends GnirsFilter("Order4", "H", "Order 4 (H: 1.65µm)", 1_650_000.pm.some, 1_860_000.pm.some)
+  case Order3 extends GnirsFilter("Order3", "K", "Order 3 (K)", 2_200_000.pm.some, 2_700_000.pm.some)
+  case Order2 extends GnirsFilter("Order2", "L", "Order 2 (L)", 3_500_000.pm.some, 4_300_000.pm.some)
+  case Order1 extends GnirsFilter("Order1", "M", "Order 1 (M)", 4_800_000.pm.some, 6_000_000.pm.some)
+  case H2 extends GnirsFilter("H2", "H2", "H2: 2.12µm", 2_120_000.pm.some, none)
+  case HNd100x extends GnirsFilter("HNd100x", "H+ND100X", "H + ND100X", 1_650_000.pm.some, none)
+  case H2Nd100x extends GnirsFilter("H2Nd100x", "H2+ND100X", "H2 + ND100X", 2_120_000.pm.some, none)
+  case PAH extends GnirsFilter("PAH", "PAH", "PAH: 3.3µm", 3_300_000.pm.some, none)
+  case Y extends GnirsFilter("Y", "Y", "Y: 1.03µm", 1_030_000.pm.some, none)
+  case J extends GnirsFilter("J", "J", "J: 1.25µm", 1_250_000.pm.some, none)
+  case K extends GnirsFilter("K", "K", "K: 2.20µm", 2_200_000.pm.some, none)
+
+object GnirsFilter:
+  private val SpectroscopyFilterTable: List[(GnirsFilter, Wavelength)] = 
+    values.map(f => f.spectroscopyCutoffWavelength.map(w => (f, w))).toList.flattenOption
+
+  // Adapted from seqexec
+  def fromSpectroscopyWavelength(wavelength: Wavelength): GnirsFilter = 
+    SpectroscopyFilterTable.foldRight[GnirsFilter](GnirsFilter.CrossDispersed):  (entry, selected) =>
+      if (wavelength < entry._2) entry._1 else selected

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -43,6 +43,8 @@ object GnirsFilter:
     values.map(f => f.spectroscopyCutoffWavelength.map(w => (f, w))).toList.flattenOption
 
   // Adapted from seqexec
-  def fromSpectroscopyWavelength(wavelength: Wavelength): GnirsFilter = 
-    SpectroscopyFilterTable.foldRight[GnirsFilter](GnirsFilter.CrossDispersed):  (entry, selected) =>
-      if (wavelength < entry._2) entry._1 else selected
+  def fromSpectroscopyWavelength(wavelength: Wavelength): Either[String, GnirsFilter] = 
+    SpectroscopyFilterTable
+      .collectFirst:
+        case (filter, cutoff) if wavelength < cutoff => filter
+      .toRight(s"No Gnirs spectroscopy filter available for wavelength: $wavelength")

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsDynamicConfig.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsDynamicConfig.scala
@@ -13,6 +13,7 @@ import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuOther
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsReadMode
+import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import monocle.Focus
 import monocle.Lens
@@ -20,6 +21,7 @@ import monocle.Lens
 final case class GnirsDynamicConfig(
   exposure:          TimeSpan,
   coadds:            PosInt,
+  centralWavelength: Wavelength,
   filter:            GnirsFilter,
   decker:            GnirsDecker,
   fpu:               Either[GnirsFpuSlit, GnirsFpuOther],
@@ -35,6 +37,9 @@ object GnirsDynamicConfig:
 
   val coadds: Lens[GnirsDynamicConfig, PosInt] =
     Focus[GnirsDynamicConfig](_.coadds)
+
+  val centralWavelength: Lens[GnirsDynamicConfig, Wavelength] =
+    Focus[GnirsDynamicConfig](_.centralWavelength)
 
   val filter: Lens[GnirsDynamicConfig, GnirsFilter] =
     Focus[GnirsDynamicConfig](_.filter)

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsDynamicConfig.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsDynamicConfig.scala
@@ -8,7 +8,9 @@ import coulomb.testkit.given
 import eu.timepit.refined.scalacheck.numeric.given
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.*
+import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbRefined.given
+import lucuma.core.math.arb.ArbWavelength.given
 import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMirrorMode
 import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
 import lucuma.core.model.sequence.gnirs.GnirsFocus
@@ -43,6 +45,7 @@ trait ArbGnirsDynamicConfig:
     for
       exposure          <- arbitrary[TimeSpan]
       coadds            <- arbitrary[PosInt]
+      centralWavelength <- arbitrary[Wavelength]
       filter            <- arbitrary[GnirsFilter]
       decker            <- arbitrary[GnirsDecker]
       fpu               <- arbitrary[Either[GnirsFpuSlit, GnirsFpuOther]]
@@ -53,6 +56,7 @@ trait ArbGnirsDynamicConfig:
     yield GnirsDynamicConfig(
       exposure,
       coadds,
+      centralWavelength,
       filter,
       decker,
       fpu,
@@ -67,6 +71,7 @@ trait ArbGnirsDynamicConfig:
       (
         TimeSpan,
         PosInt,
+        Wavelength,
         GnirsFilter,
         GnirsDecker,
         Either[GnirsFpuSlit, GnirsFpuOther],
@@ -79,6 +84,7 @@ trait ArbGnirsDynamicConfig:
       (
         x.exposure,
         x.coadds,
+        x.centralWavelength,
         x.filter,
         x.decker,
         x.fpu,


### PR DESCRIPTION
- It seems that in Gnirs the central wavelength can be specified instead of using the filter's.

- In old ITC, the spectroscopy filter is resolved depending on the wavelength. In GPP we will deduce it using seqexec's logic and pass it to ITC.