### PR TITLE
GHOST package object

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/package.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.ghost
+
+import lucuma.core.math.Wavelength
+
+/**
+ * The fixed value for the GHOST central wavelength.
+ */
+val CentralWavelength: Wavelength = Wavelength.fromIntNanometers(655).get


### PR DESCRIPTION
Adds a GHOST package object to store GHOST-related constants, with the `CentralWavelength` being the only example for now.  Upon request, this will replace a similar value in the `odb` source.