### PR TITLE
Gnirs grating names

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsGrating.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsGrating.scala
@@ -18,6 +18,6 @@ enum GnirsGrating(
   val longName: String,
   val rulingDensity: Int
 ) derives Enumerated, Display:
-  case D10 extends GnirsGrating("D10", "10 l/mm", "10 l/mm grating", 10)
-  case D32 extends GnirsGrating("D32", "32 l/mm", "32 l/mm grating", 32)
-  case D111 extends GnirsGrating("D111", "111 l/mm", "111 l/mm grating", 111)
+  case D10 extends GnirsGrating("D10", "10", "10 l/mm", 10)
+  case D32 extends GnirsGrating("D32", "32", "32 l/mm", 32)
+  case D111 extends GnirsGrating("D111", "111", "111 l/mm", 111)


### PR DESCRIPTION
Revert the GnirsGrating shortName since it's used when decoding the table. Adjust the longName instead.