### PR TITLE
Add geometry for NS FPUs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.196"
+ThisBuild / tlBaseVersion                         := "0.197"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
@@ -9,6 +9,7 @@ import cats.data.NonEmptyList
 import cats.data.NonEmptyMap
 import cats.derived.*
 import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.enums.GmosFpuType
 import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosSouthFpu
 import lucuma.core.enums.GuideProbe
@@ -204,11 +205,13 @@ object AgsParams:
       fpu:  Either[GmosNorthFpu, GmosSouthFpu],
       port: PortDisposition = PortDisposition.Side
     ): GmosLongSlit =
-      require(isLongSlit(fpu), s"FPU must be a long-slit, got: $fpu")
+      require(supportedFpu(fpu), s"FPU must be a long-slit or N&S, got: $fpu")
       new GmosLongSlit(fpu, port, GuideProbe.GmosOIWFS)
 
-    private def isLongSlit(fpu: Either[GmosNorthFpu, GmosSouthFpu]): Boolean =
-      fpu.fold(_.tag.startsWith("LongSlit"), _.tag.startsWith("LongSlit"))
+    private def supportedFpu(fpu: Either[GmosNorthFpu, GmosSouthFpu]): Boolean =
+      fpu.fold(_.fpuType, _.fpuType) match
+        case GmosFpuType.LongSlit | GmosFpuType.Ns => true
+        case GmosFpuType.Ifu                       => false
 
   case class Flamingos2LongSlit private (
     lyot:  Flamingos2LyotWheel,

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosFpuType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosFpuType.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma
+package core
+package enums
+
+import lucuma.core.util.Enumerated
+
+enum GmosFpuType(val tag: String) derives Enumerated:
+  case LongSlit extends GmosFpuType("LongSlit")
+  case Ns       extends GmosFpuType("Ns")
+  case Ifu      extends GmosFpuType("Ifu")

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosNorthFpu.scala
@@ -5,6 +5,7 @@ package lucuma
 package core
 package enums
 
+import cats.syntax.eq.*
 import lucuma.core.math.Angle
 import lucuma.core.util.Enumerated
 
@@ -17,23 +18,24 @@ enum GmosNorthFpu(
   val longName: String,
   val effectiveSlitWidth: Angle,
   val xOffset: Angle,
-  val isIFU: Boolean
+  val fpuType: GmosFpuType
 ) derives Enumerated:
 
-  case Ns0 extends           GmosNorthFpu("Ns0",           "NS0.25\"", "N and S 0.25 arcsec",  Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns1 extends           GmosNorthFpu("Ns1",           "NS0.5\"",  "N and S 0.50 arcsec",  Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns2 extends           GmosNorthFpu("Ns2",           "NS0.75\"", "N and S 0.75 arcsec",  Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns3 extends           GmosNorthFpu("Ns3",           "NS1.0\"",  "N and S 1.00 arcsec",  Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns4 extends           GmosNorthFpu("Ns4",           "NS1.5\"",  "N and S 1.50 arcsec",  Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns5 extends           GmosNorthFpu("Ns5",           "NS2.0\"",  "N and S 2.00 arcsec",  Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_25 extends GmosNorthFpu("LongSlit_0_25", "0.25\"",   "Longslit 0.25 arcsec", Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_50 extends GmosNorthFpu("LongSlit_0_50", "0.50\"",   "Longslit 0.50 arcsec", Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_75 extends GmosNorthFpu("LongSlit_0_75", "0.75\"",   "Longslit 0.75 arcsec", Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_1_00 extends GmosNorthFpu("LongSlit_1_00", "1.0\"",    "Longslit 1.00 arcsec", Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_1_50 extends GmosNorthFpu("LongSlit_1_50", "1.5\"",    "Longslit 1.50 arcsec", Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_2_00 extends GmosNorthFpu("LongSlit_2_00", "2.0\"",    "Longslit 2.00 arcsec", Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_5_00 extends GmosNorthFpu("LongSlit_5_00", "5.0\"",    "Longslit 5.00 arcsec", Angle.milliarcseconds.reverseGet(5000), Angle.fromDoubleArcseconds(0.000), false)
-  case Ifu2Slits extends     GmosNorthFpu("Ifu2Slits",     "IFU-2",    "IFU 2 Slits",          Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(33.500), true)
-  case IfuBlue extends       GmosNorthFpu("IfuBlue",       "IFU-B",    "IFU Left Slit (blue)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(31.750), true)
-  case IfuRed extends        GmosNorthFpu("IfuRed",        "IFU-R",    "IFU Right Slit (red)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(35.250), true)
+  case Ns0 extends           GmosNorthFpu("Ns0",           "NS0.25\"", "N and S 0.25 arcsec",  Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case Ns1 extends           GmosNorthFpu("Ns1",           "NS0.5\"",  "N and S 0.50 arcsec",  Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case Ns2 extends           GmosNorthFpu("Ns2",           "NS0.75\"", "N and S 0.75 arcsec",  Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case Ns3 extends           GmosNorthFpu("Ns3",           "NS1.0\"",  "N and S 1.00 arcsec",  Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case Ns4 extends           GmosNorthFpu("Ns4",           "NS1.5\"",  "N and S 1.50 arcsec",  Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case Ns5 extends           GmosNorthFpu("Ns5",           "NS2.0\"",  "N and S 2.00 arcsec",  Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.Ns)
+  case LongSlit_0_25 extends GmosNorthFpu("LongSlit_0_25", "0.25\"",   "Longslit 0.25 arcsec", Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_0_50 extends GmosNorthFpu("LongSlit_0_50", "0.50\"",   "Longslit 0.50 arcsec", Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_0_75 extends GmosNorthFpu("LongSlit_0_75", "0.75\"",   "Longslit 0.75 arcsec", Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_1_00 extends GmosNorthFpu("LongSlit_1_00", "1.0\"",    "Longslit 1.00 arcsec", Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_1_50 extends GmosNorthFpu("LongSlit_1_50", "1.5\"",    "Longslit 1.50 arcsec", Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_2_00 extends GmosNorthFpu("LongSlit_2_00", "2.0\"",    "Longslit 2.00 arcsec", Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case LongSlit_5_00 extends GmosNorthFpu("LongSlit_5_00", "5.0\"",    "Longslit 5.00 arcsec", Angle.milliarcseconds.reverseGet(5000), Angle.fromDoubleArcseconds(0.000),  GmosFpuType.LongSlit)
+  case Ifu2Slits extends     GmosNorthFpu("Ifu2Slits",     "IFU-2",    "IFU 2 Slits",          Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(33.500), GmosFpuType.Ifu)
+  case IfuBlue extends       GmosNorthFpu("IfuBlue",       "IFU-B",    "IFU Left Slit (blue)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(31.750), GmosFpuType.Ifu)
+  case IfuRed extends        GmosNorthFpu("IfuRed",        "IFU-R",    "IFU Right Slit (red)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(35.250), GmosFpuType.Ifu)
 
+  def isIFU: Boolean = fpuType === GmosFpuType.Ifu

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFpu.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GmosSouthFpu.scala
@@ -5,6 +5,7 @@ package lucuma
 package core
 package enums
 
+import cats.syntax.eq.*
 import lucuma.core.math.Angle
 import lucuma.core.util.Enumerated
 
@@ -17,25 +18,26 @@ enum GmosSouthFpu(
   val longName: String,
   val effectiveSlitWidth: Angle,
   val xOffset: Angle,
-  val isIFU: Boolean
+  val fpuType: GmosFpuType
 ) derives Enumerated:
 
-  case Ns1           extends GmosSouthFpu("Ns1",           "NS0.5\"",  "N and S 0.50 arcsec",          Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns2           extends GmosSouthFpu("Ns2",           "NS0.75\"", "N and S 0.75 arcsec",          Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns3           extends GmosSouthFpu("Ns3",           "NS1.0\"",  "N and S 1.00 arcsec",          Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns4           extends GmosSouthFpu("Ns4",           "NS1.5\"",  "N and S 1.50 arcsec",          Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000), false)
-  case Ns5           extends GmosSouthFpu("Ns5",           "NS2.0\"",  "N and S 2.00 arcsec",          Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_25 extends GmosSouthFpu("LongSlit_0_25", "0.25\"",   "Longslit 0.25 arcsec",         Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_50 extends GmosSouthFpu("LongSlit_0_50", "0.50\"",   "Longslit 0.50 arcsec",         Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_0_75 extends GmosSouthFpu("LongSlit_0_75", "0.75\"",   "Longslit 0.75 arcsec",         Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_1_00 extends GmosSouthFpu("LongSlit_1_00", "1.0\"",    "Longslit 1.00 arcsec",         Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_1_50 extends GmosSouthFpu("LongSlit_1_50", "1.5\"",    "Longslit 1.50 arcsec",         Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_2_00 extends GmosSouthFpu("LongSlit_2_00", "2.0\"",    "Longslit 2.00 arcsec",         Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000), false)
-  case LongSlit_5_00 extends GmosSouthFpu("LongSlit_5_00", "5.0\"",    "Longslit 5.00 arcsec",         Angle.milliarcseconds.reverseGet(5000), Angle.fromDoubleArcseconds(0.000), false)
-  case Ifu2Slits     extends GmosSouthFpu("Ifu2Slits",     "IFU-2",    "IFU 2 Slits",                  Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-31.750), true)
-  case IfuBlue       extends GmosSouthFpu("IfuBlue",       "IFU-B",    "IFU Left Slit (blue)",         Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-30.875), true)
-  case IfuRed        extends GmosSouthFpu("IfuRed",        "IFU-R",    "IFU Right Slit (red)",         Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-32.625), true)
-  case IfuNS2Slits   extends GmosSouthFpu("IfuNS2Slits",   "IFU-NS-2", "IFU N and S 2 Slits",          Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-31.750), true)
-  case IfuNSBlue     extends GmosSouthFpu("IfuNSBlue",     "IFU-NS-B", "IFU N and S Left Slit (blue)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-30.875), true)
-  case IfuNSRed      extends GmosSouthFpu("IfuNSRed",      "IFU-NS-R", "IFU N and S Right Slit (red)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-32.625), true)
+  case Ns1           extends GmosSouthFpu("Ns1",           "NS0.5\"",  "N and S 0.50 arcsec",          Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.Ns)
+  case Ns2           extends GmosSouthFpu("Ns2",           "NS0.75\"", "N and S 0.75 arcsec",          Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.Ns)
+  case Ns3           extends GmosSouthFpu("Ns3",           "NS1.0\"",  "N and S 1.00 arcsec",          Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.Ns)
+  case Ns4           extends GmosSouthFpu("Ns4",           "NS1.5\"",  "N and S 1.50 arcsec",          Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.Ns)
+  case Ns5           extends GmosSouthFpu("Ns5",           "NS2.0\"",  "N and S 2.00 arcsec",          Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.Ns)
+  case LongSlit_0_25 extends GmosSouthFpu("LongSlit_0_25", "0.25\"",   "Longslit 0.25 arcsec",         Angle.milliarcseconds.reverseGet( 250), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_0_50 extends GmosSouthFpu("LongSlit_0_50", "0.50\"",   "Longslit 0.50 arcsec",         Angle.milliarcseconds.reverseGet( 500), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_0_75 extends GmosSouthFpu("LongSlit_0_75", "0.75\"",   "Longslit 0.75 arcsec",         Angle.milliarcseconds.reverseGet( 750), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_1_00 extends GmosSouthFpu("LongSlit_1_00", "1.0\"",    "Longslit 1.00 arcsec",         Angle.milliarcseconds.reverseGet(1000), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_1_50 extends GmosSouthFpu("LongSlit_1_50", "1.5\"",    "Longslit 1.50 arcsec",         Angle.milliarcseconds.reverseGet(1500), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_2_00 extends GmosSouthFpu("LongSlit_2_00", "2.0\"",    "Longslit 2.00 arcsec",         Angle.milliarcseconds.reverseGet(2000), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case LongSlit_5_00 extends GmosSouthFpu("LongSlit_5_00", "5.0\"",    "Longslit 5.00 arcsec",         Angle.milliarcseconds.reverseGet(5000), Angle.fromDoubleArcseconds(0.000),   GmosFpuType.LongSlit)
+  case Ifu2Slits     extends GmosSouthFpu("Ifu2Slits",     "IFU-2",    "IFU 2 Slits",                  Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-31.750), GmosFpuType.Ifu)
+  case IfuBlue       extends GmosSouthFpu("IfuBlue",       "IFU-B",    "IFU Left Slit (blue)",         Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-30.875), GmosFpuType.Ifu)
+  case IfuRed        extends GmosSouthFpu("IfuRed",        "IFU-R",    "IFU Right Slit (red)",         Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-32.625), GmosFpuType.Ifu)
+  case IfuNS2Slits   extends GmosSouthFpu("IfuNS2Slits",   "IFU-NS-2", "IFU N and S 2 Slits",          Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-31.750), GmosFpuType.Ifu)
+  case IfuNSBlue     extends GmosSouthFpu("IfuNSBlue",     "IFU-NS-B", "IFU N and S Left Slit (blue)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-30.875), GmosFpuType.Ifu)
+  case IfuNSRed      extends GmosSouthFpu("IfuNSRed",      "IFU-NS-R", "IFU N and S Right Slit (red)", Angle.milliarcseconds.reverseGet( 310), Angle.fromDoubleArcseconds(-32.625), GmosFpuType.Ifu)
 
+  def isIFU: Boolean = fpuType === GmosFpuType.Ifu

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ObservingModeType.scala
@@ -16,10 +16,10 @@ object ObservingModeType:
   export FacilityObservingModeType.{ values => _, * }
   export VisitorObservingModeType.{ values => _, * }
   val values = FacilityObservingModeType.values ++ VisitorObservingModeType.values
-    
+
 enum FacilityObservingModeType(
-  val tag: String, 
-  val instrument: Instrument, 
+  val tag: String,
+  val instrument: Instrument,
   val defaultPosAngleConstraint: PosAngleConstraint
 ) extends ObservingModeType derives Enumerated:
   case Flamingos2LongSlit extends FacilityObservingModeType("flamingos_2_long_slit", Instrument.Flamingos2, PosAngleConstraint.AverageParallactic)
@@ -32,7 +32,7 @@ enum FacilityObservingModeType(
   case Igrins2LongSlit    extends FacilityObservingModeType("igrins_2_long_slit",    Instrument.Igrins2,    PosAngleConstraint.AverageParallactic)
 
 enum VisitorObservingModeType(
-  val tag: String, 
+  val tag: String,
   val instrument: Instrument
 ) extends ObservingModeType derives Enumerated:
   val defaultPosAngleConstraint = PosAngleConstraint.Fixed(Angle.Angle0) // for all visitors

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/GmosScienceAreaGeometry.scala
@@ -44,9 +44,12 @@ trait GmosScienceAreaGeometry {
   private def shapeFromLongSlitFpu(fpu: Either[GmosNorthFpu, GmosSouthFpu]): ShapeExpression =
     fpu.fold(
       {
-        case GmosNorthFpu.Ns0 | GmosNorthFpu.Ns1 | GmosNorthFpu.Ns2 | GmosNorthFpu.Ns3 |
-             GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5 | GmosNorthFpu.Ifu2Slits | GmosNorthFpu.IfuBlue |
-             GmosNorthFpu.IfuRed =>
+        case n @ (GmosNorthFpu.Ns0 | GmosNorthFpu.Ns1 |
+                  GmosNorthFpu.Ns2 | GmosNorthFpu.Ns3 |
+                  GmosNorthFpu.Ns4 | GmosNorthFpu.Ns5) =>
+          nsFov(n.effectiveSlitWidth)
+
+        case GmosNorthFpu.Ifu2Slits | GmosNorthFpu.IfuBlue | GmosNorthFpu.IfuRed =>
           ShapeExpression.empty
 
         case n@(GmosNorthFpu.LongSlit_0_25 | GmosNorthFpu.LongSlit_0_50 |
@@ -56,8 +59,12 @@ trait GmosScienceAreaGeometry {
           longSlitFov(n.effectiveSlitWidth)
       },
       {
-        case GmosSouthFpu.Ns1 | GmosSouthFpu.Ns2 | GmosSouthFpu.Ns3 |
-             GmosSouthFpu.Ns4 | GmosSouthFpu.Ns5 | GmosSouthFpu.Ifu2Slits | GmosSouthFpu.IfuBlue |
+        case n@(GmosSouthFpu.Ns1 | GmosSouthFpu.Ns2 |
+                GmosSouthFpu.Ns3 | GmosSouthFpu.Ns4 |
+                GmosSouthFpu.Ns5) =>
+          nsFov(n.effectiveSlitWidth)
+
+        case GmosSouthFpu.Ifu2Slits | GmosSouthFpu.IfuBlue |
              GmosSouthFpu.IfuRed | GmosSouthFpu.IfuNS2Slits | GmosSouthFpu.IfuNSBlue |
              GmosSouthFpu.IfuNSRed =>
           ShapeExpression.empty
@@ -97,7 +104,7 @@ trait GmosScienceAreaGeometry {
   }
 
   def longSlitFov(width: Angle): ShapeExpression = {
-    val h = 108000.mas
+    val h = LongSlitHeight
     val g = 3200.mas
 
     val x = width.bisect
@@ -110,6 +117,8 @@ trait GmosScienceAreaGeometry {
     }
   }
 
+  private def nsFov(size: Angle): ShapeExpression =
+    ShapeExpression.centeredRectangle(size, NodAndShuffleHeight)
 }
 
 object scienceArea extends GmosScienceAreaGeometry

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
@@ -12,9 +12,9 @@ import lucuma.core.enums.GmosSouthFpu
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int.*
 import lucuma.core.math.syntax.units.*
 import lucuma.core.math.units.*
-import lucuma.core.math.syntax.int.*
 
 val GmosPixelScale: PixelScale = 0.0807.pixelScale
 

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/gmos/package.scala
@@ -14,8 +14,13 @@ import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.math.syntax.units.*
 import lucuma.core.math.units.*
+import lucuma.core.math.syntax.int.*
 
 val GmosPixelScale: PixelScale = 0.0807.pixelScale
+
+val LongSlitHeight: Angle = 108000.mas
+
+val NodAndShuffleHeight: Angle = 108000.mas
 
 def gmosSlitWidthPixels(slitWidth: Angle, xBin: GmosXBinning): Quantity[BigDecimal, Pixels] =
   val widthArcSeconds = Angle.decimalArcseconds.get(slitWidth).arcsecs

--- a/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
+++ b/modules/tests/jvm/src/main/scala/lucuma/core/geom/jts/demo/JtsDemo.scala
@@ -36,7 +36,7 @@ trait InstrumentShapes:
   def shapes: List[ShapeExpression]
   def coloredShapes: List[ColoredShape] = Nil
 
-trait GmosLSShapes extends InstrumentShapes:
+trait GmosShapes extends InstrumentShapes:
   import lucuma.core.geom.gmos.*
   import lucuma.core.geom.gmos.oiwfs.{probeArm, patrolField}
 
@@ -49,8 +49,7 @@ trait GmosLSShapes extends InstrumentShapes:
   val offsetPos: Offset =
     Offset(-60.arcsec.p, 60.arcsec.q)
 
-  val fpu: Either[GmosNorthFpu, GmosSouthFpu] =
-    Right(GmosSouthFpu.LongSlit_5_00)
+  def fpu: Either[GmosNorthFpu, GmosSouthFpu]
 
   val port: PortDisposition =
     PortDisposition.Side
@@ -63,6 +62,14 @@ trait GmosLSShapes extends InstrumentShapes:
       scienceArea.longSlitMode.shapeAt(posAngle, offsetPos, fpu),
       candidatesArea.candidatesAreaAt(posAngle, offsetPos)
     )
+
+trait GmosLSShapes extends GmosShapes:
+  override val fpu: Either[GmosNorthFpu, GmosSouthFpu] =
+    Right(GmosSouthFpu.LongSlit_5_00)
+
+trait GmosNSShapes extends GmosShapes:
+  override val fpu: Either[GmosNorthFpu, GmosSouthFpu] =
+    Right(GmosSouthFpu.Ns5)
 
 trait GmosImagingShapes extends InstrumentShapes:
   import lucuma.core.geom.gmos.*
@@ -337,6 +344,8 @@ class JtsDemo extends Frame("JTS Demo") {
 }
 
 object JtsGmosLSDemo extends JtsDemo with GmosLSShapes
+
+object JtsGmosNSDemo extends JtsDemo with GmosNSShapes
 
 object JtsFlamingos2LSDemo extends JtsDemo with Flamingos2LSShapes
 


### PR DESCRIPTION
We have some observations in the database using Node and Shuffle and they break when calling AGS. In this pull request we add the geometry for N&S and allow ags to use them