### PR TITLE
Sc 8464 update workflow for visitor modes

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
@@ -40,6 +40,12 @@ enum ExecutionState(val tag: String) derives Enumerated:
    */
   case DeclaredOngoing extends ExecutionState("declared_ongoing")
 
-  /** Union type of declared (i.e., non-computed) states. */
-  type DeclaredExecutionState = DeclaredComplete.type | DeclaredOngoing.type
 
+/** Union type of declared (i.e., non-computed) states. */
+type DeclaredExecutionState = 
+  ExecutionState.DeclaredComplete.type | 
+  ExecutionState.DeclaredOngoing.type
+
+object DeclaredExecutionState:
+  given Enumerated[DeclaredExecutionState] =
+    Enumerated.from(ExecutionState.DeclaredOngoing, ExecutionState.DeclaredComplete).withTag(_.tag)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/ExecutionState.scala
@@ -33,3 +33,13 @@ enum ExecutionState(val tag: String) derives Enumerated:
    * though more atoms and/or steps remain.
    */
   case DeclaredComplete extends ExecutionState("declared_complete")
+
+  /**
+   * The observation has been explicitly declared ongoing, though no atoms 
+   * and/or steps remain. This state is only valid for visitor mode observations.
+   */
+  case DeclaredOngoing extends ExecutionState("declared_ongoing")
+
+  /** Union type of declared (i.e., non-computed) states. */
+  type DeclaredExecutionState = DeclaredComplete.type | DeclaredOngoing.type
+


### PR DESCRIPTION
This adds a `DeclaredOngoing` exec state to support visitor modes.