### PR TITLE
Add maroonx ags params

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.199"
+ThisBuild / tlBaseVersion                         := "0.200"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
@@ -22,6 +22,8 @@ import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.jts.interpreter.given
 import lucuma.core.geom.offsets.OffsetPosition
 import lucuma.core.geom.syntax.all.*
+import lucuma.core.geom.visitors.MaroonXScienceFov
+import lucuma.core.geom.visitors.maroonXScienceArea
 import lucuma.core.geom.visitors.visitorScienceArea
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
@@ -48,6 +50,12 @@ trait SingleProbeAgsParams:
   def probeArm(posAngle: Angle, guideStar: Offset, offset: Offset): ShapeExpression
 
   def scienceRadius: Angle
+
+  /**
+   * Optional region that reperesent the area where we measure vignetting. In most cases it is just
+   * the science area
+   */
+  def extendedVignettingArea: Option[(Angle, Offset) => ShapeExpression] = None
 
   def posCalculations(
     positions: NonEmptyList[OffsetPosition]
@@ -83,6 +91,12 @@ trait SingleProbeAgsParams:
         private val scienceAreaShapeEval: Shape =
           scienceAreaShape.eval
 
+        // Default to the science area for the vignetting score; instruments
+        // may extend it with an additional region.
+        private val vignettingShapeEval: Shape =
+          extendedVignettingArea
+            .fold(scienceAreaShapeEval)(_.apply(position.posAngle, position.offsetPos).eval)
+
         override def isReachable(gsOffset: Offset): Boolean =
           // Fast bounding box rejection, then precise check
           intersectionBounds.contains(gsOffset) && intersectionShape.contains(gsOffset)
@@ -93,7 +107,7 @@ trait SingleProbeAgsParams:
 
         override def vignettingArea(gsOffset: Offset): Area =
           probeArm(position.posAngle, gsOffset, position.offsetPos).eval
-            .intersection(scienceAreaShapeEval)
+            .intersection(vignettingShapeEval)
             .area
 
       }
@@ -328,7 +342,6 @@ object AgsParams:
       copy(probe = probe)
 
     override def scienceArea(posAngle: Angle, offset: Offset): ShapeExpression =
-      // Approximate maroonX as a circle
       visitorScienceArea.shapeAt(posAngle, offset, scienceFov)
 
     override def scienceRadius: Angle =
@@ -337,3 +350,25 @@ object AgsParams:
   object Visitor:
     def apply(scienceRadius: Angle, port: PortDisposition = PortDisposition.Bottom): Visitor =
       Visitor(scienceRadius, port, GuideProbe.PWFS2)
+
+  case class MaroonX private (
+    port:  PortDisposition,
+    probe: PWFSGuideProbe
+  ) extends AgsParams
+      with PwfsOnlyParams
+      with PwfsSupport[MaroonX] derives Eq:
+
+    protected def withPWFSProbe(probe: PWFSGuideProbe): MaroonX =
+      copy(probe = probe)
+
+    override def scienceArea(posAngle: Angle, offset: Offset): ShapeExpression =
+      maroonXScienceArea.shapeAt(posAngle, offset)
+
+    override val extendedVignettingArea: Option[(Angle, Offset) => ShapeExpression] =
+      Some(maroonXScienceArea.extendedVignettingAreaAt)
+
+    override def scienceRadius: Angle = MaroonXScienceFov
+
+  object MaroonX:
+    def apply(port: PortDisposition = PortDisposition.Bottom): MaroonX =
+      MaroonX(port, GuideProbe.PWFS2)

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/Instrument.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/Instrument.scala
@@ -26,7 +26,7 @@ enum Instrument(val tag: String, val shortName: String, val longName: String, va
   /** @group Constructors */ case Gnirs        extends Instrument("Gnirs", "GNIRS", "GNIRS", "GNIRS".refined[NonEmpty], false)
   /** @group Constructors */ case Gpi          extends Instrument("Gpi", "GPI", "GPI", "GPI".refined[NonEmpty], false)
   /** @group Constructors */ case Gsaoi        extends Instrument("Gsaoi", "GSAOI", "GSAOI", "GSAOI".refined[NonEmpty], false)
-  /** @group Constructors */ case Igrins2      extends Instrument("Igrins2", "IGRINS2", "IGRINS2", "IGRINS2".refined[NonEmpty], false)
+  /** @group Constructors */ case Igrins2      extends Instrument("Igrins2", "IGRINS-2", "IGRINS-2", "IGRINS2".refined[NonEmpty], false)
   /** @group Constructors */ case MaroonX      extends Instrument("MaroonX", "MAROON-X", "MAROON-X", "MAROONX".refined[NonEmpty], false)
   /** @group Constructors */ case Niri         extends Instrument("Niri", "NIRI", "NIRI", "NIRI".refined[NonEmpty], false)
   /** @group Constructors */ case Scorpio      extends Instrument("Scorpio", "SCORPIO", "Scorpio", "SCORPIO".refined[NonEmpty], false)

--- a/modules/core/shared/src/main/scala/lucuma/core/geom/visitors/MaroonXScienceAreaGeometry.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/geom/visitors/MaroonXScienceAreaGeometry.scala
@@ -13,7 +13,12 @@ import lucuma.core.math.Offset
  *
  * https://www.gemini.edu/instrumentation/maroon-x/components
  *
- * Light is fed by a 100 um octagonal fiber at f/3.3, which projects to a 0.77" flat-to-flat fiberShape on sky.
+ * Light is fed by a 100 um octagonal fiber at f/3.3, which projects to a 0.77″
+ * flat-to-flat fiber on sky.
+ *
+ * MAROON-X also has a sky fiber at r=20 arcseconds, and observations are done
+ * with the CRCS fixed, so the sky rotates around the science fiber during
+ * observations.
  */
 trait MaroonXScienceAreaGeometry:
 
@@ -24,7 +29,7 @@ trait MaroonXScienceAreaGeometry:
   // circumscribed radius for an octagon is diameter / (2 * cos(pi/8)).
   val fiberShape: ShapeExpression =
     val octagonWidth = MaroonXScienceFov.toMicroarcseconds.toDouble
-    val radius     = Angle.fromMicroarcseconds(
+    val radius       = Angle.fromMicroarcseconds(
       (octagonWidth / (2.0 * Math.cos(Math.PI / 8.0))).round
     )
     ShapeExpression.regularPolygon(radius, 8)
@@ -33,17 +38,11 @@ trait MaroonXScienceAreaGeometry:
     // Does the fiber rotate with pos angle?
     fiberShape.shapeAt(offsetPos, posAngle)
 
-object maroonXScienceArea extends MaroonXScienceAreaGeometry
-
-trait MaroonXPatrolFieldGeometry:
-
-/**
- * MAROON-X has a sky fiber at r=20 arcseconds, and observations are done with the
- * CRCS fixed, so the sky rotates around the science fiber during observations.
- *
- * The probe should not vignette anything inside a fov diameter of 60 arcsec.
- */
-  val patrolField: ShapeExpression =
+  // Extra protected region: the 60"-diameter circle the sky fiber sweeps
+  val extendedVignettingArea: ShapeExpression =
     ShapeExpression.centeredEllipse(MaroonXSkyFiberPatrol, MaroonXSkyFiberPatrol)
 
-object maroonXPatrolField extends MaroonXPatrolFieldGeometry
+  def extendedVignettingAreaAt(posAngle: Angle, offsetPos: Offset): ShapeExpression =
+    extendedVignettingArea.shapeAt(offsetPos, posAngle)
+
+object maroonXScienceArea extends MaroonXScienceAreaGeometry


### PR DESCRIPTION
MaroonX requires an extended area where we consider vignetting beyond the actual science fiber