### PR TITLE
Cache intersection shapes per posAngle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.203"
+ThisBuild / tlBaseVersion                         := "0.204"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/ags/src/main/scala/lucuma/ags/Ags.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/Ags.scala
@@ -35,7 +35,8 @@ object Ags {
   private case class AgsContextBuffer(
     guideSpeeds:          List[(GuideSpeed, BrightnessConstraints)],
     calcs:                NonEmptyMap[OffsetPosition, AgsGeomCalc],
-    brightnessConstraint: Option[BrightnessConstraints]
+    brightnessConstraint: Option[BrightnessConstraints],
+    calcsNanos:           Long // time spent in posCalculations
   )
 
   private def guideSpeedFor(
@@ -166,9 +167,11 @@ object Ags {
     params:      AgsParams
   ): AgsContextBuffer = {
     val guideSpeeds = guideSpeedLimits(constraints, params.probe, wavelength)
+    val calcsStart  = System.nanoTime()
     val calcs       = params.posCalculations(positions)
+    val calcsNanos  = System.nanoTime() - calcsStart
     val bc          = constraintsFor(guideSpeeds)
-    AgsContextBuffer(guideSpeeds, calcs, bc)
+    AgsContextBuffer(guideSpeeds, calcs, bc, calcsNanos)
   }
 
   /**
@@ -299,6 +302,7 @@ object Ags {
       positions.size,
       analyses,
       ctxEnd - ctxStart,
+      ctx.calcsNanos,
       anEnd - anStart
     )
   }

--- a/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/AgsParams.scala
@@ -60,14 +60,31 @@ trait SingleProbeAgsParams:
   def posCalculations(
     positions: NonEmptyList[OffsetPosition]
   ): NonEmptyMap[OffsetPosition, AgsGeomCalc] =
+    val distinctOffsets: NonEmptyList[(Offset, Offset)] =
+      positions.map(pos => (pos.offsetPos, pos.pivot)).distinct
+
+    // We can cache the intersection shapes for each tested pos angle.
+    val intersectionByPA: Map[Angle, (ShapeExpression, Shape, BoundingOffsets)] =
+      positions.toList
+        .map(_.posAngle)
+        .distinct
+        .map: posAngle =>
+          val se: ShapeExpression =
+            distinctOffsets
+              .map((offset, pivot) => patrolFieldAt(posAngle, offset, pivot))
+              .reduce(using _ ∩ _)
+
+          // eval is expensive. call it only once.
+          val shape = se.eval
+          posAngle -> (se, shape, shape.boundingOffsets)
+        .toMap
+
     val result = positions.map: position =>
+      val (pfExpr, pfShape, pfBounds) = intersectionByPA(position.posAngle)
+
       position -> new AgsGeomCalc() {
-        override val intersectionPatrolField: ShapeExpression =
-          positions
-            .map(pos => (pos.offsetPos, pos.pivot))
-            .distinct
-            .map((offset, pivot) => patrolFieldAt(position.posAngle, offset, pivot))
-            .reduce(using _ ∩ _)
+
+        override val intersectionPatrolField: ShapeExpression = pfExpr
 
         private val scienceAreaShape =
           scienceArea(position.posAngle, position.offsetPos)
@@ -77,13 +94,10 @@ trait SingleProbeAgsParams:
                                           scienceRadius
           ) ↗ position.offsetPos ⟲ position.posAngle
 
-        // Cache shapes to avoid re-computation
-        private val intersectionShape: Shape =
-          intersectionPatrolField.eval
+        private val intersectionShape: Shape = pfShape
 
         // Cache bounding box for fast rejection
-        private val intersectionBounds: BoundingOffsets =
-          intersectionShape.boundingOffsets
+        private val intersectionBounds: BoundingOffsets = pfBounds
 
         private val scienceTargetShape: Shape =
           scienceTargetArea.eval

--- a/modules/ags/src/main/scala/lucuma/ags/package.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/package.scala
@@ -248,6 +248,7 @@ object AgsAnalysisResult:
     positionCount:  Int,
     analyses:       List[AgsAnalysis],
     contextNanos:   Long,
+    calcsNanos:     Long,
     analysisNanos:  Long
   ): AgsAnalysisResult =
     val usableCandidates = analyses.collect { case u: AgsAnalysis.Usable => u.target.id }.toSet.size
@@ -264,6 +265,7 @@ object AgsAnalysisResult:
         analyses.size,
         analyses.groupMapReduce(Ags.resultLabel)(_ => 1)(_ + _),
         contextNanos,
+        calcsNanos,
         analysisNanos
       )
     )
@@ -291,6 +293,8 @@ object AgsAnalysisResult:
  *   histogram of outcomes keyed by [[Ags.resultLabel]]
  * @param contextNanos
  *   monotonic ns spent building the per-position geometry context
+ * @param calcsNanos
+ *   monotonic ns spent in posCalculations
  * @param analysisNanos
  *   monotonic ns spent in the runAnalysis loop (JTS work)
  */
@@ -305,6 +309,7 @@ case class AgsStats(
   analysisCount:        Int,
   resultCounts:         Map[String, Int],
   contextNanos:         Long,
+  calcsNanos:           Long,
   analysisNanos:        Long
 ):
   def format: String =
@@ -325,9 +330,10 @@ case class AgsStats(
         |  candidates:   $candidateCount supplied, $acceptedCount accepted, $usableCandidateCount usable
         |  geometry:     $posAngleCount pos angles, $acqOffsetCount acq + $sciOffsetCount sci offsets, $positionCount positions
         |  analyses:     $analysisCount runAnalysis calls
-        |  timing:       context ${ms(contextNanos)}, analysis ${ms(analysisNanos)}, total ${ms(
-         totalNanos
-       )}
+        |  ctx timing:   ${ms(contextNanos)}
+        |  calcs timing: ${ms(calcsNanos)}
+        |  analysis time:${ms(analysisNanos)}
+        |  total time:   ${ms(totalNanos)}
         |  outcomes:
         |$histogram""".stripMargin
 

--- a/modules/ags/src/main/scala/lucuma/ags/package.scala
+++ b/modules/ags/src/main/scala/lucuma/ags/package.scala
@@ -4,6 +4,7 @@
 package lucuma.ags
 
 import cats.Order.given
+import cats.Show
 import cats.data.NonEmptyList
 import cats.data.NonEmptySet
 import cats.syntax.all.*
@@ -305,4 +306,30 @@ case class AgsStats(
   resultCounts:         Map[String, Int],
   contextNanos:         Long,
   analysisNanos:        Long
-)
+):
+  def format: String =
+    def ms(nanos: Long): String = f"${nanos / 1.0e6}%.2f ms"
+
+    val totalNanos = contextNanos + analysisNanos
+    val histogram  =
+      if (resultCounts.isEmpty) "    (none)"
+      else
+        resultCounts.toList
+          .sortBy: (label, cnt) =>
+            (-cnt, label)
+          .map: (label, cnt) =>
+            f"    $label%-18s $cnt"
+          .mkString("\n")
+
+    s"""|AGS stats:
+        |  candidates:   $candidateCount supplied, $acceptedCount accepted, $usableCandidateCount usable
+        |  geometry:     $posAngleCount pos angles, $acqOffsetCount acq + $sciOffsetCount sci offsets, $positionCount positions
+        |  analyses:     $analysisCount runAnalysis calls
+        |  timing:       context ${ms(contextNanos)}, analysis ${ms(analysisNanos)}, total ${ms(
+         totalNanos
+       )}
+        |  outcomes:
+        |$histogram""".stripMargin
+
+object AgsStats:
+  given Show[AgsStats] = Show.show(_.format)


### PR DESCRIPTION
Doing some tests, we can avoid recomputing some of the intersection shapes precalculating them per `posAngle`
This is more evident for obs with many offests as the shapes are recalculated over and over