### PR TITLE
GnirsAcquisitionMode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.205"
+ThisBuild / tlBaseVersion                         := "0.206"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsAcquisitionType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsAcquisitionType.scala
@@ -5,17 +5,9 @@ package lucuma.core.enums
 
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
-import lucuma.core.util.TimeSpan
 
 // Similar values to GnirsReadMode but unrelated.
 enum GnirsAcquisitionType(val tag: String, val shortName: String, val longName: String) derives Enumerated, Display:
   case VeryBright extends GnirsAcquisitionType("VeryBright", "Very Bright", "Very Bright Target")
   case Bright extends GnirsAcquisitionType("Bright", "Bright", "Bright Target")
   case Faint extends GnirsAcquisitionType("Faint", "Faint", "Faint Target")
-
-object GnirsAcquisitionType:
-  def forAcquisitionExposureTime(t: TimeSpan): GnirsAcquisitionType =
-    val exposureSeconds: BigDecimal = t.toSeconds
-    if (exposureSeconds < 1) GnirsAcquisitionType.VeryBright
-    else if (exposureSeconds <= 10) GnirsAcquisitionType.Bright
-    else GnirsAcquisitionType.Faint

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -51,7 +51,6 @@ object GnirsFilter:
   private val SpectroscopyFilterTable: List[(GnirsFilter, BoundedInterval[Wavelength])] = 
     values.map(f => f.spectroscopyRange.map(w => (f, w))).toList.flattenOption
 
-  // ATTENTION: This logic is duplicated in the DB view in the ODB. Modify it there too if it's changed here.
   def fromSpectroscopyWavelength(wavelength: Wavelength): Either[String, GnirsFilter] = 
     SpectroscopyFilterTable
       .collectFirst:

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/gnirs/GnirsAcquisitionMode.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.gnirs
+
+import cats.Eq
+import cats.derived.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.GnirsAcquisitionType
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.bigDecimal.*
+import lucuma.core.util.TimeSpan
+import monocle.Focus
+import monocle.Iso
+import monocle.Optional
+import monocle.Prism
+import monocle.macros.GenPrism
+
+/**
+  * Gnirs has 3 acquisition sequence generation modes: Very Bright, Bright and Faint.
+  * Faint mode also requires a sky offset, which the other 2 modes don't.
+  */
+enum GnirsAcquisitionMode(val acquisitionType: GnirsAcquisitionType) derives Eq:
+  case VeryBright extends GnirsAcquisitionMode(GnirsAcquisitionType.VeryBright)
+  case Bright extends GnirsAcquisitionMode(GnirsAcquisitionType.Bright)
+  case Faint(skyOffset: Offset) extends GnirsAcquisitionMode(GnirsAcquisitionType.Faint)
+
+object GnirsAcquisitionMode:
+  object Faint {
+    val DefaultSkyOffset: Offset = Offset(0.pArcsec, -2.qArcsec)
+
+    val Default: GnirsAcquisitionMode.Faint =
+      GnirsAcquisitionMode.Faint(DefaultSkyOffset)
+
+    val skyOffset: Iso[GnirsAcquisitionMode.Faint, Offset] = Focus[GnirsAcquisitionMode.Faint](_.skyOffset)
+  }
+
+  val veryBright: Prism[GnirsAcquisitionMode, GnirsAcquisitionMode.VeryBright.type] = 
+    GenPrism[GnirsAcquisitionMode, GnirsAcquisitionMode.VeryBright.type]
+
+  val bright: Prism[GnirsAcquisitionMode, GnirsAcquisitionMode.Bright.type] = 
+    GenPrism[GnirsAcquisitionMode, GnirsAcquisitionMode.Bright.type]
+
+  val faint: Prism[GnirsAcquisitionMode, GnirsAcquisitionMode.Faint] = 
+    GenPrism[GnirsAcquisitionMode, GnirsAcquisitionMode.Faint]
+
+  val skyOffset: Optional[GnirsAcquisitionMode, Offset] =
+    faint.andThen(Faint.skyOffset)
+
+  def forTypeAndOffset(acquisitionType: GnirsAcquisitionType, skyOffset: Option[Offset]): GnirsAcquisitionMode =
+    acquisitionType match
+      case GnirsAcquisitionType.VeryBright => VeryBright
+      case GnirsAcquisitionType.Bright => Bright
+      case GnirsAcquisitionType.Faint => Faint(skyOffset.getOrElse(Faint.DefaultSkyOffset))
+
+  // Default value depends on integration time (exposure time * coadds).
+  def defaultFor(exposureTime: TimeSpan, coadds: PosInt): GnirsAcquisitionMode =
+    val integrationTimeSeconds: BigDecimal = exposureTime.toSeconds * coadds.value
+    if (integrationTimeSeconds < 1) GnirsAcquisitionMode.VeryBright
+    else if (integrationTimeSeconds < 10) GnirsAcquisitionMode.Bright
+    else GnirsAcquisitionMode.Faint.Default

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsAcquisitionMode.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/gnirs/arb/ArbGnirsAcquisitionMode.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.core.model.sequence.gnirs.arb
+
+import lucuma.core.math.Offset
+import lucuma.core.math.arb.ArbOffset.given
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMode
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbGnirsAcquisitionMode:
+  given Arbitrary[GnirsAcquisitionMode.Faint] = Arbitrary:
+    arbitrary[Offset].map(skyOffset => GnirsAcquisitionMode.Faint(skyOffset))
+
+  given Cogen[GnirsAcquisitionMode.Faint] =
+    Cogen[Offset].contramap(_.skyOffset)
+
+  given Arbitrary[GnirsAcquisitionMode] = Arbitrary:
+    Gen.oneOf(
+      Gen.const(GnirsAcquisitionMode.VeryBright),
+      Gen.const(GnirsAcquisitionMode.Bright),
+      arbitrary[GnirsAcquisitionMode.Faint]
+    )
+
+  given Cogen[GnirsAcquisitionMode] =
+    Cogen[Either[Unit, Either[Unit, GnirsAcquisitionMode.Faint]]]
+      .contramap:
+        case GnirsAcquisitionMode.VeryBright => Left(())
+        case GnirsAcquisitionMode.Bright     => Right(Left(()))
+        case m @ GnirsAcquisitionMode.Faint(_)      => Right(Right(m))
+
+object ArbGnirsAcquisitionMode extends ArbGnirsAcquisitionMode


### PR DESCRIPTION
The `Faint` acquisition mode in Gnirs requires a skyoffset.

This PR models this to be used downstream.