### PR TITLE
Shortcut 8595: GHOST IFU Mapping (Again)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalajs.linker.interface.ESVersion
 import org.typelevel.sbt.gha.PermissionValue
 import org.typelevel.sbt.gha.Permissions
 
-ThisBuild / tlBaseVersion                         := "0.206"
+ThisBuild / tlBaseVersion                         := "0.207"
 ThisBuild / tlCiReleaseBranches                   := Seq("master")
 ThisBuild / githubWorkflowEnv += "MUNIT_FLAKY_OK" -> "true"
 

--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GhostIfuMappingType.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GhostIfuMappingType.scala
@@ -6,7 +6,6 @@ package lucuma.core.enums
 import lucuma.core.util.Enumerated
 
 enum GhostIfuMappingType(val tag: String, val name: String) derives Enumerated:
-  case Nonsidereal   extends GhostIfuMappingType("nonsidereal",     "Nonsidereal")
   case SingleTarget  extends GhostIfuMappingType("single_target",   "Single Target")
   case TargetPlusSky extends GhostIfuMappingType("target_plus_sky", "Target+Sky")
   case SkyPlusTarget extends GhostIfuMappingType("sky_plus_target", "Sky+Target")

--- a/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostIfuMapping.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/model/sequence/ghost/GhostIfuMapping.scala
@@ -8,7 +8,7 @@ import cats.derived.*
 import cats.syntax.eq.*
 import lucuma.core.enums.GhostIfuMappingType
 import lucuma.core.math.Coordinates
-import lucuma.core.model.SiderealTracking
+import lucuma.core.model.Target
 import monocle.Prism
 import monocle.macros.GenPrism
 
@@ -17,14 +17,11 @@ sealed trait GhostIfuMapping:
 
 object GhostIfuMapping:
 
-  case object Nonsidereal extends GhostIfuMapping derives Eq:
-    override def mappingType: GhostIfuMappingType = GhostIfuMappingType.Nonsidereal
-
   /**
    * Only IFU1 is used for single target mode.
    */
   case class SingleTarget(
-    ifu1: SiderealTracking
+    ifu1: Target.Id
   ) extends GhostIfuMapping derives Eq:
     override def mappingType: GhostIfuMappingType = GhostIfuMappingType.SingleTarget
 
@@ -32,7 +29,7 @@ object GhostIfuMapping:
    * IFU1 is a sidereal target, IFU2 is a sky position.
    */
   case class TargetPlusSky(
-    ifu1: SiderealTracking,
+    ifu1: Target.Id,
     ifu2: Coordinates
   ) extends GhostIfuMapping derives Eq:
     override def mappingType: GhostIfuMappingType = GhostIfuMappingType.TargetPlusSky
@@ -42,7 +39,7 @@ object GhostIfuMapping:
    */
   case class SkyPlusTarget(
     ifu1: Coordinates,
-    ifu2: SiderealTracking
+    ifu2: Target.Id
   ) extends GhostIfuMapping derives Eq:
     override def mappingType: GhostIfuMappingType = GhostIfuMappingType.SkyPlusTarget
 
@@ -50,22 +47,18 @@ object GhostIfuMapping:
    * IFU1 and IFU2 are sidereal targets.
    */
   case class DualTarget(
-    ifu1: SiderealTracking,
-    ifu2: SiderealTracking
+    ifu1: Target.Id,
+    ifu2: Target.Id
   ) extends GhostIfuMapping derives Eq:
     override def mappingType: GhostIfuMappingType = GhostIfuMappingType.DualTarget
 
   given Eq[GhostIfuMapping] =
     Eq.instance:
-      case (Nonsidereal,      Nonsidereal)      => true
       case (a: SingleTarget,  b: SingleTarget)  => a === b
       case (a: SkyPlusTarget, b: SkyPlusTarget) => a === b
       case (a: TargetPlusSky, b: TargetPlusSky) => a === b
       case (a: DualTarget,    b: DualTarget)    => a === b
       case _                                    => false
-
-  val nonsidereal: Prism[GhostIfuMapping, Nonsidereal.type] =
-    GenPrism[GhostIfuMapping, Nonsidereal.type]
 
   val singleTarget: Prism[GhostIfuMapping, SingleTarget] =
     GenPrism[GhostIfuMapping, SingleTarget]

--- a/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostIfuMapping.scala
+++ b/modules/testkit/src/main/scala/lucuma/core/model/sequence/ghost/arb/ArbGhostIfuMapping.scala
@@ -7,8 +7,8 @@ package arb
 
 import lucuma.core.math.Coordinates
 import lucuma.core.math.arb.ArbCoordinates
-import lucuma.core.model.SiderealTracking
-import lucuma.core.model.arb.ArbSiderealTracking
+import lucuma.core.model.Target
+import lucuma.core.util.arb.ArbGid
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen
@@ -17,58 +17,53 @@ import org.scalacheck.Gen
 trait ArbGhostIfuMapping:
 
   import ArbCoordinates.given
-  import ArbSiderealTracking.given
+  import ArbGid.given
 
   import GhostIfuMapping.*
 
-  given Arbitrary[Nonsidereal.type] =
-    Arbitrary:
-      Gen.const(Nonsidereal)
-
   given Arbitrary[SingleTarget] =
     Arbitrary:
-      arbitrary[SiderealTracking].map(SingleTarget(_))
+      arbitrary[Target.Id].map(SingleTarget(_))
 
   given Cogen[SingleTarget] =
-    Cogen[SiderealTracking].contramap(_.ifu1)
+    Cogen[Target.Id].contramap(_.ifu1)
 
   given Arbitrary[TargetPlusSky] =
     Arbitrary:
       for
-        t <- arbitrary[SiderealTracking]
+        t <- arbitrary[Target.Id]
         c <- arbitrary[Coordinates]
       yield TargetPlusSky(t, c)
 
   given Cogen[TargetPlusSky] =
-    Cogen[(SiderealTracking, Coordinates)].contramap: a =>
+    Cogen[(Target.Id, Coordinates)].contramap: a =>
       (a.ifu1, a.ifu2)
 
   given Arbitrary[SkyPlusTarget] =
     Arbitrary:
       for
         c <- arbitrary[Coordinates]
-        t <- arbitrary[SiderealTracking]
+        t <- arbitrary[Target.Id]
       yield SkyPlusTarget(c, t)
 
   given Cogen[SkyPlusTarget] =
-    Cogen[(Coordinates, SiderealTracking)].contramap: a =>
+    Cogen[(Coordinates, Target.Id)].contramap: a =>
       (a.ifu1, a.ifu2)
 
   given Arbitrary[DualTarget] =
     Arbitrary:
       for
-        t0 <- arbitrary[SiderealTracking]
-        t1 <- arbitrary[SiderealTracking]
+        t0 <- arbitrary[Target.Id]
+        t1 <- arbitrary[Target.Id]
       yield DualTarget(t0, t1)
 
   given Cogen[DualTarget] =
-    Cogen[(SiderealTracking, SiderealTracking)].contramap: a =>
+    Cogen[(Target.Id, Target.Id)].contramap: a =>
       (a.ifu1, a.ifu2)
 
   given Arbitrary[GhostIfuMapping] =
     Arbitrary:
       Gen.oneOf(
-        arbitrary[Nonsidereal.type],
         arbitrary[SingleTarget],
         arbitrary[TargetPlusSky],
         arbitrary[SkyPlusTarget],
@@ -78,15 +73,14 @@ trait ArbGhostIfuMapping:
   given Cogen[GhostIfuMapping] =
     Cogen[(
       Int,
-      Option[SiderealTracking],
-      Option[(SiderealTracking, Coordinates)],
-      Option[(Coordinates, SiderealTracking)],
-      Option[(SiderealTracking, SiderealTracking)]
+      Option[Target.Id],
+      Option[(Target.Id, Coordinates)],
+      Option[(Coordinates, Target.Id)],
+      Option[(Target.Id, Target.Id)]
     )].contramap:
-      case Nonsidereal         => (0, None, None, None, None)
-      case SingleTarget(t)     => (1, Some(t), None, None, None)
-      case TargetPlusSky(t, c) => (2, None, Some((t, c)), None, None)
-      case SkyPlusTarget(c, t) => (3, None, None, Some((c, t)), None)
-      case DualTarget(t0, t1)  => (4, None, None, None, Some((t0, t1)))
+      case SingleTarget(t)     => (0, Some(t), None, None, None)
+      case TargetPlusSky(t, c) => (1, None, Some((t, c)), None, None)
+      case SkyPlusTarget(c, t) => (2, None, None, Some((c, t)), None)
+      case DualTarget(t0, t1)  => (3, None, None, None, Some((t0, t1)))
 
 object ArbGhostIfuMapping extends ArbGhostIfuMapping


### PR DESCRIPTION
The [initial battle plan](https://github.com/gemini-hlsw/lucuma-core/pull/1400) did not survive contact with the enemy.    We ended up needing more information than just the sidereal tracking (name, source profile, ...) so we decided to punt and just map to target ids.  Observe will read the IFU mapping along with the observation asterism and get the target details it needs from there.

I removed the explicit `Nonsidereal` mapping option.  The nonsidereal mapping will always be `SingleTarget` with a target id that refers to a nonsidereal target.  This unfortunately doesn't preclude, based on the API alone, the possibility of having dual nonsidereal or nonsidereal + sky mappings.  The ODB won't produce these though and Observe should just error out if one is nevertheless somehow encountered.  