### PR TITLE
Remove obsolete comment

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsFilter.scala
@@ -58,7 +58,6 @@ object GnirsFilter:
       .toRight(s"No Gnirs spectroscopy filter available for wavelength: $wavelength")
 
   /** Acquisition filter options. */
-  // ATTENTION: This logic is duplicated in the DB view in the ODB. Modify it there too if it's changed here.
   val acquisition: NonEmptyList[GnirsFilter] =
     NonEmptyList.of(Order6, J, Order4, H2, K, PAH)
 


### PR DESCRIPTION
Since we have auto-acquisition filter option, the acquisition filter is computed in code and so the DB table in ODB no longer has the information of which filters are acquisition filters.