### PR TITLE
Fix readouttime (typo?)

### DIFF
--- a/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsReadMode.scala
+++ b/modules/core/shared/src/main/scala/lucuma/core/enums/GnirsReadMode.scala
@@ -25,7 +25,7 @@ enum GnirsReadMode(
 ) derives Enumerated, Display:
     case VeryBright extends GnirsReadMode("VeryBright", "Very bright", "Very Bright Acquisition or High Background", 100.msTimeSpan, 190.msTimeSpan, 155, 1, 1)
     case Bright extends GnirsReadMode("Bright", "Bright", "Bright objects", 600.msTimeSpan, 690.msTimeSpan, 30, 1, 16)
-    case Faint extends GnirsReadMode("Faint", "Faint", "Faint objects", 9000.msTimeSpan, 11400.msTimeSpan, 10, 16, 16)
+    case Faint extends GnirsReadMode("Faint", "Faint", "Faint objects", 9000.msTimeSpan, 11140.msTimeSpan, 10, 16, 16)
     case VeryFaint extends GnirsReadMode("VeryFaint", "Very faint", "Very faint objects", 18000.msTimeSpan, 22310.msTimeSpan, 7, 32, 16)
 
 object GnirsReadMode:


### PR DESCRIPTION
There was a slight discrepancy with https://github.com/gemini-hlsw/seqexec/blob/main/modules/server/src/main/scala/seqexec/server/gnirs/GnirsController.scala#L158, probably a typo.

Faint readout time per coadd is 11.14s, not 11.4.